### PR TITLE
chore: expand project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 提示：所有命令行输出与错误信息均为中文；代码实现为英文。
 
 ## 依赖与环境
-- Python 3.9+
-- 依赖：tushare、pandas、pyyaml、numpy
+- Python 3.10+
+- 依赖：tushare、pandas、pyyaml、numpy、python-dotenv
 - TuShare Token：优先读取环境变量 `TUSHARE_TOKEN`，也可通过 `--token` 传入
 
 安装依赖（推荐使用 uv 或 pip）：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "tushare-a-fundamentals"
 version = "0.2.0"
 description = "A-share income statement downloader using TuShare"
 readme = "README.md"
+authors = [{ name = "Richard" }]
+license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "tushare>=1.2.89",
@@ -14,6 +16,9 @@ dependencies = [
 
 [project.scripts]
 income-downloader = "app:main"
+
+[tool.setuptools]
+py-modules = ["app"]
 
 [tool.uv]
 python-preference = "only-managed"
@@ -31,11 +36,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 select = ["E", "F", "W", "C90"]
 
 [tool.ruff.mccabe]


### PR DESCRIPTION
## Summary
- add authors and license info to project metadata
- specify app module for packaging and update formatter versions
- document Python 3.10+ and python-dotenv dependency

## Testing
- `ruff check .` *(fails: F401 `typing.Tuple` imported but unused, E501, E702, F841, W291)*
- `pytest` *(fails: test_cli_overrides_config, test_diff_to_single_cumulative_to_quarterly, test_ttm_rolling_sum_min4)*

------
https://chatgpt.com/codex/tasks/task_e_68c40dc9d6ac8327acc5d3a25ae5947a