### PR TITLE
feat: map modes to periodicity and view

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ income-downloader --help
 或直接从源码运行：
 
 ```bash
-python3 -m tushare_a_fundamentals.app --help
+python3 -m tushare_a_fundamentals.cli --help
 ```
 
 ## 配置文件
@@ -72,7 +72,7 @@ python3 -m tushare_a_fundamentals.app --help
     或：
 
     ```
-    python3 -m tushare_a_fundamentals.app --mode quarterly --quarters 40 --vip --prefer-single-quarter
+    python3 -m tushare_a_fundamentals.cli --mode quarterly --quarters 40 --vip --prefer-single-quarter
     ```
 
 * 全市场，年度，近 12 年，存 parquet：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.scripts]
-income-downloader = "tushare_a_fundamentals.app:main"
+income-downloader = "tushare_a_fundamentals.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/tests/integration/test_cli_overrides.py
+++ b/tests/integration/test_cli_overrides.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import yaml
 import subprocess
 import pytest
@@ -6,7 +7,7 @@ import pytest
 pytestmark = pytest.mark.integration
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-APP = os.path.join(ROOT, "src", "app.py")
+ENV = {**os.environ, "PYTHONPATH": os.path.join(ROOT, "src")}
 
 
 def test_cli_overrides_config(tmp_path):
@@ -15,8 +16,9 @@ def test_cli_overrides_config(tmp_path):
     cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
     code = subprocess.run(
         [
-            "python3",
-            APP,
+            sys.executable,
+            "-m",
+            "tushare_a_fundamentals.cli",
             "--config",
             str(cfg_path),
             "--mode",
@@ -27,5 +29,6 @@ def test_cli_overrides_config(tmp_path):
         ],
         capture_output=True,
         text=True,
+        env=ENV,
     )
     assert code.returncode != 2

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -1,30 +1,32 @@
 import os
+import sys
 import subprocess
 import pytest
 
 pytestmark = pytest.mark.integration
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-APP = os.path.join(ROOT, "src", "app.py")
+
+
+def run_cli(*args):
+    env = {**os.environ, "PYTHONPATH": os.path.join(ROOT, "src")}
+    return subprocess.run(
+        [sys.executable, "-m", "tushare_a_fundamentals.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
 
 def test_error_no_token_env(monkeypatch):
     monkeypatch.delenv("TUSHARE_TOKEN", raising=False)
-    p = subprocess.run(
-        ["python3", APP, "--mode", "annual", "--years", "1", "--vip"],
-        capture_output=True,
-        text=True,
-    )
+    p = run_cli("--mode", "annual", "--years", "1", "--vip")
     assert p.returncode == 2
     assert "缺少 TuShare token" in p.stderr
 
 
 def test_error_no_vip_no_ts_code(monkeypatch):
     monkeypatch.setenv("TUSHARE_TOKEN", "dummy")
-    p = subprocess.run(
-        ["python3", APP, "--mode", "annual", "--years", "1", "--no-vip"],
-        capture_output=True,
-        text=True,
-    )
+    p = run_cli("--mode", "annual", "--years", "1", "--no-vip")
     assert p.returncode == 2
     assert "未提供 --ts-code 且未启用 --vip" in p.stderr

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -5,7 +5,7 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import app as appmod
+from tushare_a_fundamentals import cli as appmod
 
 
 def test_select_latest_priority():

--- a/tests/unit/test_diff_single.py
+++ b/tests/unit/test_diff_single.py
@@ -5,7 +5,7 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import app as appmod
+from tushare_a_fundamentals import cli as appmod
 
 
 def test_diff_to_single_cumulative_to_quarterly():

--- a/tests/unit/test_periods.py
+++ b/tests/unit/test_periods.py
@@ -4,7 +4,7 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import app as appmod
+from tushare_a_fundamentals import cli as appmod
 
 
 def test_periods_years_annual():

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -1,0 +1,32 @@
+import pytest
+from tushare_a_fundamentals import cli as appmod
+
+pytestmark = pytest.mark.unit
+
+
+def test_plan_mapping():
+    p = appmod.plan_from_mode("annual")
+    assert p.periodicity == "annual"
+    assert p.view == "reported"
+
+    p = appmod.plan_from_mode("quarter")
+    assert p.periodicity == "quarterly"
+    assert p.view == "quarter"
+
+    p = appmod.plan_from_mode("ttm")
+    assert p.periodicity == "quarterly"
+    assert p.view == "ttm"
+
+
+def test_plan_override():
+    p = appmod.plan_from_mode("annual", periodicity="quarterly")
+    assert p.periodicity == "quarterly"
+    assert p.view == "reported"
+
+
+def test_plan_deprecated_alias(capfd):
+    p = appmod.plan_from_mode("quarterly")
+    assert p.periodicity == "quarterly"
+    assert p.view == "quarter"
+    err = capfd.readouterr().err
+    assert "已弃用" in err

--- a/tests/unit/test_save_naming.py
+++ b/tests/unit/test_save_naming.py
@@ -5,7 +5,7 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import app as appmod
+from tushare_a_fundamentals import cli as appmod
 
 
 def test_save_naming(tmp_path):
@@ -15,7 +15,7 @@ def test_save_naming(tmp_path):
         "ttm": pd.DataFrame({"ts_code": ["000001.SZ"], "end_date": ["20231231"]}),
     }
     outdir = tmp_path
-    appmod.save_tables(tables, str(outdir), "income_vip_quarterly", "csv")
-    assert (outdir / "income_vip_quarterly_raw.csv").exists()
-    assert (outdir / "income_vip_quarterly_single.csv").exists()
-    assert (outdir / "income_vip_quarterly_ttm.csv").exists()
+    appmod.save_tables(tables, str(outdir), "income_vip_quarter", "csv")
+    assert (outdir / "csv" / "income_vip_quarter_raw.csv").exists()
+    assert (outdir / "csv" / "income_vip_quarter_single.csv").exists()
+    assert (outdir / "csv" / "income_vip_quarter_ttm.csv").exists()

--- a/tests/unit/test_ttm.py
+++ b/tests/unit/test_ttm.py
@@ -1,11 +1,12 @@
 import os
 import sys
+import math
 import pandas as pd
 import pytest
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import app as appmod
+from tushare_a_fundamentals import cli as appmod
 
 
 def test_ttm_rolling_sum_min4():
@@ -16,5 +17,5 @@ def test_ttm_rolling_sum_min4():
     })
     ttm = appmod._rolling_ttm(df)
     vals = ttm["total_revenue"].tolist()
-    assert vals[:3] == [None, None, None]
+    assert all(math.isnan(v) for v in vals[:3])
     assert vals[3] == 70.0


### PR DESCRIPTION
## Summary
- introduce Plan dataclass mapping user-facing modes to periodicity and view
- accept deprecated `quarterly` alias while warning users
- rename main entry from `app` to `cli` and drop duplicate wrapper

## Testing
- `TUSHARE_TOKEN=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d542e7f88327abfa3e1c84496b58