### PR TITLE
feat: skip existing outputs and default to parquet

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,5 +1,5 @@
 # 示例配置（请复制为 config.yml 并按需修改）
-mode: quarterly
+mode: quarter
 years: 10
 # quarters: 40
 # ts_code: 600000.SH
@@ -9,4 +9,5 @@ fields: "ts_code,ann_date,f_ann_date,end_date,report_type,comp_type,update_flag,
 outdir: "out"
 prefix: "income"
 format: "parquet"
+skip_existing: false
 # token: "your_tushare_token"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyyaml>=6.0",
     "numpy>=1.24.0",
     "python-dotenv>=1.0.0",
+    "pyarrow>=14.0.0",
 ]
 
 [project.scripts]

--- a/tests/integration/test_cli_overrides.py
+++ b/tests/integration/test_cli_overrides.py
@@ -7,7 +7,7 @@ import pytest
 pytestmark = pytest.mark.integration
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-ENV = {**os.environ, "PYTHONPATH": os.path.join(ROOT, "src")}
+ENV = {**os.environ, "PYTHONPATH": os.path.join(ROOT, "src"), "TUSHARE_TOKEN": "fake"}
 
 
 def test_cli_overrides_config(tmp_path):

--- a/tests/unit/test_concat_non_empty.py
+++ b/tests/unit/test_concat_non_empty.py
@@ -1,0 +1,13 @@
+import warnings
+import pandas as pd
+from tushare_a_fundamentals.cli import _concat_non_empty
+
+
+def test_concat_non_empty_filters_all_na():
+    df1 = pd.DataFrame({"a": [1]})
+    df2 = pd.DataFrame({"a": [None]})
+    df3 = pd.DataFrame({"a": [2]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = _concat_non_empty([df1, df2, df3])
+    assert out.shape[0] == 2

--- a/tests/unit/test_convert_parquet_to_csv.py
+++ b/tests/unit/test_convert_parquet_to_csv.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "tools"))
+from convert_parquet_to_csv import convert_parquet_to_csv
+
+pytestmark = pytest.mark.unit
+
+
+def test_convert_parquet_to_csv(tmp_path):
+    pytest.importorskip("pyarrow")
+    src = tmp_path / "parquet"
+    dest = tmp_path / "csv"
+    src.mkdir()
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    df.to_parquet(src / "foo.parquet")
+    convert_parquet_to_csv(src, dest)
+    out = dest / "foo.csv"
+    assert out.exists()
+    df2 = pd.read_csv(out)
+    assert df.equals(df2)

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -1,34 +1,35 @@
-import os
-import sys
 import pandas as pd
 import pytest
+from tushare_a_fundamentals import cli as appmod
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import cli as appmod
-
 
 def test_select_latest_priority():
-    df = pd.DataFrame({
-        "ts_code": ["000001.SZ"]*3,
-        "end_date": ["20231231"]*3,
-        "report_type": [2, 1, 2],
-        "f_ann_date": ["20240201", "20240131", "20240210"],
-        "ann_date": ["20240201", "20240131", "20240209"],
-    })
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ"] * 3,
+            "end_date": ["20231231"] * 3,
+            "report_type": [2, 1, 2],
+            "f_ann_date": ["20240201", "20240131", "20240210"],
+            "ann_date": ["20240201", "20240131", "20240209"],
+        }
+    )
     got = appmod._select_latest(df)
     assert len(got) == 1
     assert int(got.iloc[0]["report_type"]) == 1
 
 
 def test_update_flag_break_tie():
-    df = pd.DataFrame({
-        "ts_code": ["000001.SZ", "000001.SZ"],
-        "end_date": ["20231231", "20231231"],
-        "report_type": [2, 2],
-        "f_ann_date": ["20240210", "20240210"],
-        "ann_date": ["20240209", "20240209"],
-        "update_flag": ["N", "Y"],
-    })
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20231231"],
+            "report_type": [2, 2],
+            "f_ann_date": ["20240210", "20240210"],
+            "ann_date": ["20240209", "20240209"],
+            "update_flag": ["N", "Y"],
+        }
+    )
     got = appmod._select_latest(df)
     assert got.iloc[0]["update_flag"] == "Y"

--- a/tests/unit/test_diff_single.py
+++ b/tests/unit/test_diff_single.py
@@ -1,19 +1,18 @@
-import os
-import sys
 import pandas as pd
 import pytest
+from tushare_a_fundamentals import cli as appmod
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import cli as appmod
-
 
 def test_diff_to_single_cumulative_to_quarterly():
-    df = pd.DataFrame({
-        "ts_code": ["000001.SZ"]*3,
-        "end_date": ["20230331", "20230630", "20230930"],
-        "total_revenue": [10.0, 25.0, 45.0],
-    })
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ"] * 3,
+            "end_date": ["20230331", "20230630", "20230930"],
+            "total_revenue": [10.0, 25.0, 45.0],
+        }
+    )
     got = appmod._diff_to_single(df)
     q1, q2, q3 = got["total_revenue"].tolist()
     assert q1 == 10.0

--- a/tests/unit/test_parquet_dependency.py
+++ b/tests/unit/test_parquet_dependency.py
@@ -1,0 +1,16 @@
+import importlib
+import pytest
+from tushare_a_fundamentals.cli import _check_parquet_dependency
+
+
+def test_parquet_dependency_present():
+    pytest.importorskip("pyarrow")
+    assert _check_parquet_dependency() is True
+
+
+def test_parquet_dependency_missing(monkeypatch):
+    def fake_import(name):
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(importlib, "import_module", lambda name: fake_import(name))
+    assert _check_parquet_dependency() is False

--- a/tests/unit/test_periods.py
+++ b/tests/unit/test_periods.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import pytest
+from tushare_a_fundamentals import cli as appmod
 
 pytestmark = pytest.mark.unit
-
-from tushare_a_fundamentals import cli as appmod
 
 
 def test_periods_years_annual():

--- a/tests/unit/test_save_naming.py
+++ b/tests/unit/test_save_naming.py
@@ -1,11 +1,8 @@
-import os
-import sys
 import pandas as pd
 import pytest
+from tushare_a_fundamentals import cli as appmod
 
 pytestmark = pytest.mark.unit
-
-from tushare_a_fundamentals import cli as appmod
 
 
 def test_save_naming(tmp_path):

--- a/tests/unit/test_ttm.py
+++ b/tests/unit/test_ttm.py
@@ -1,20 +1,19 @@
-import os
-import sys
 import math
 import pandas as pd
 import pytest
+from tushare_a_fundamentals import cli as appmod
 
 pytestmark = pytest.mark.unit
 
-from tushare_a_fundamentals import cli as appmod
-
 
 def test_ttm_rolling_sum_min4():
-    df = pd.DataFrame({
-        "ts_code": ["000001.SZ"]*4,
-        "end_date": ["20230331", "20230630", "20230930", "20231231"],
-        "total_revenue": [10.0, 15.0, 20.0, 25.0],
-    })
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ"] * 4,
+            "end_date": ["20230331", "20230630", "20230930", "20231231"],
+            "total_revenue": [10.0, 15.0, 20.0, 25.0],
+        }
+    )
     ttm = appmod._rolling_ttm(df)
     vals = ttm["total_revenue"].tolist()
     assert all(math.isnan(v) for v in vals[:3])

--- a/tools/convert_parquet_to_csv.py
+++ b/tools/convert_parquet_to_csv.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Convert existing parquet outputs to csv."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import pandas as pd
+
+
+def convert_parquet_to_csv(src: str | Path, dest: str | Path) -> None:
+    src_dir = Path(src)
+    dest_dir = Path(dest)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for p in src_dir.glob("*.parquet"):
+        df = pd.read_parquet(p)
+        out_file = dest_dir / (p.stem + ".csv")
+        df.to_csv(out_file, index=False)
+        print(f"已转换：{p} -> {out_file}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="parquet 转 csv")
+    parser.add_argument("--src", default="out/parquet")
+    parser.add_argument("--dest", default="out/csv")
+    args = parser.parse_args()
+    convert_parquet_to_csv(args.src, args.dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -444,6 +444,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc", size = 1133487, upload-time = "2025-07-18T00:57:31.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e563271e2c5ff4d4a4cbeb2c83d5cf0d4938b891518e676025f7268c6fe5fe26", size = 31196837, upload-time = "2025-07-18T00:54:34.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5f/c1c1997613abf24fceb087e79432d24c19bc6f7259cab57c2c8e5e545fab/pyarrow-21.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79", size = 32659470, upload-time = "2025-07-18T00:54:38.329Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ed/b1589a777816ee33ba123ba1e4f8f02243a844fed0deec97bde9fb21a5cf/pyarrow-21.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:7be45519b830f7c24b21d630a31d48bcebfd5d4d7f9d3bdb49da9cdf6d764edb", size = 41055619, upload-time = "2025-07-18T00:54:42.172Z" },
+    { url = "https://files.pythonhosted.org/packages/44/28/b6672962639e85dc0ac36f71ab3a8f5f38e01b51343d7aa372a6b56fa3f3/pyarrow-21.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:26bfd95f6bff443ceae63c65dc7e048670b7e98bc892210acba7e4995d3d4b51", size = 42733488, upload-time = "2025-07-18T00:54:47.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/cc/de02c3614874b9089c94eac093f90ca5dfa6d5afe45de3ba847fd950fdf1/pyarrow-21.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bd04ec08f7f8bd113c55868bd3fc442a9db67c27af098c5f814a3091e71cc61a", size = 43329159, upload-time = "2025-07-18T00:54:51.686Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3e/99473332ac40278f196e105ce30b79ab8affab12f6194802f2593d6b0be2/pyarrow-21.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9b0b14b49ac10654332a805aedfc0147fb3469cbf8ea951b3d040dab12372594", size = 45050567, upload-time = "2025-07-18T00:54:56.679Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f5/c372ef60593d713e8bfbb7e0c743501605f0ad00719146dc075faf11172b/pyarrow-21.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:9d9f8bcb4c3be7738add259738abdeddc363de1b80e3310e04067aa1ca596634", size = 26217959, upload-time = "2025-07-18T00:55:00.482Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/80564a3071a57c20b7c32575e4a0120e8a330ef487c319b122942d665960/pyarrow-21.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b", size = 31243234, upload-time = "2025-07-18T00:55:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/cc/3b51cb2db26fe535d14f74cab4c79b191ed9a8cd4cbba45e2379b5ca2746/pyarrow-21.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10", size = 32714370, upload-time = "2025-07-18T00:55:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/a4431f36d5ad7d83b87146f515c063e4d07ef0b7240876ddb885e6b44f2e/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e", size = 41135424, upload-time = "2025-07-18T00:55:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/74/dc/035d54638fc5d2971cbf1e987ccd45f1091c83bcf747281cf6cc25e72c88/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569", size = 42823810, upload-time = "2025-07-18T00:55:16.301Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3b/89fced102448a9e3e0d4dded1f37fa3ce4700f02cdb8665457fcc8015f5b/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e", size = 43391538, upload-time = "2025-07-18T00:55:23.82Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/ea7f1bd08978d39debd3b23611c293f64a642557e8141c80635d501e6d53/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c", size = 45120056, upload-time = "2025-07-18T00:55:28.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0b/77ea0600009842b30ceebc3337639a7380cd946061b620ac1a2f3cb541e2/pyarrow-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6", size = 26220568, upload-time = "2025-07-18T00:55:32.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d4/d4f817b21aacc30195cf6a46ba041dd1be827efa4a623cc8bf39a1c2a0c0/pyarrow-21.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3a302f0e0963db37e0a24a70c56cf91a4faa0bca51c23812279ca2e23481fccd", size = 31160305, upload-time = "2025-07-18T00:55:35.373Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9c/dcd38ce6e4b4d9a19e1d36914cb8e2b1da4e6003dd075474c4cfcdfe0601/pyarrow-21.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:b6b27cf01e243871390474a211a7922bfbe3bda21e39bc9160daf0da3fe48876", size = 32684264, upload-time = "2025-07-18T00:55:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/2a2d9f8d7a59b639523454bec12dba35ae3d0a07d8ab529dc0809f74b23c/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e72a8ec6b868e258a2cd2672d91f2860ad532d590ce94cdf7d5e7ec674ccf03d", size = 41108099, upload-time = "2025-07-18T00:55:42.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/90/2660332eeb31303c13b653ea566a9918484b6e4d6b9d2d46879a33ab0622/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e", size = 42829529, upload-time = "2025-07-18T00:55:47.069Z" },
+    { url = "https://files.pythonhosted.org/packages/33/27/1a93a25c92717f6aa0fca06eb4700860577d016cd3ae51aad0e0488ac899/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82", size = 43367883, upload-time = "2025-07-18T00:55:53.069Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d9/4d09d919f35d599bc05c6950095e358c3e15148ead26292dfca1fb659b0c/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623", size = 45133802, upload-time = "2025-07-18T00:55:57.714Z" },
+    { url = "https://files.pythonhosted.org/packages/71/30/f3795b6e192c3ab881325ffe172e526499eb3780e306a15103a2764916a2/pyarrow-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf56ec8b0a5c8c9d7021d6fd754e688104f9ebebf1bf4449613c9531f5346a18", size = 26203175, upload-time = "2025-07-18T00:56:01.364Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -723,6 +752,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
+    { name = "pyarrow" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "tushare" },
@@ -740,6 +770,7 @@ dev = [
 requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pandas", specifier = ">=1.5.0" },
+    { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tushare", specifier = ">=1.2.89" },


### PR DESCRIPTION
## Summary
- make parquet the default output format and update mode documentation
- add helper script to convert parquet outputs to csv

## Testing
- `ruff check .`
- `black src/tushare_a_fundamentals/cli.py tools/convert_parquet_to_csv.py tests/integration/test_cli_overrides.py tests/unit/test_convert_parquet_to_csv.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f980987883278f564b0010e23a55