### PR TITLE
Simplify CLI defaults and enforce credit check

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ funda --help
 python -m tushare_a_fundamentals.cli --help
 ```
 
-示例：全市场批量（VIP）：
+示例：全市场最近 3 年：
 
 ```bash
-funda --mode quarterly --years 3 --vip
+funda --years 3
 ```
 
 单票下载并输出 TTM：
 
 ```bash
-funda --mode ttm --ts-code 600000.SH --years 5
+funda --ts-code 600000.SH --years 5
 ```
 
 ### 两步法：ingest + build（推荐）
@@ -80,7 +80,7 @@ funda --mode ttm --ts-code 600000.SH --years 5
 
 ```bash
 funda ingest --since 2018-01-01 --periods quarterly \
-  --prefer-single-quarter --vip \
+  --prefer-single-quarter \
   --dataset-root data_root
 ```
 
@@ -108,7 +108,7 @@ funda build --kinds annual,quarterly,ttm \
 若希望将“最新快照（或全量历史）”写入按年分区的 Parquet 数据集，可提供数据集配置并指定数据根目录：
 
 ```bash
-funda --mode quarterly --years 3 --vip \
+funda --years 3 \
   --datasets-config configs/datasets.yaml \
   --dataset-root data_root
 ```

--- a/config.example.yml
+++ b/config.example.yml
@@ -3,7 +3,6 @@ mode: quarterly               #
 years: 10
 # quarters: 40
 # ts_code: 600000.SH
-vip: true
 prefer_single_quarter: true
 fields: "ts_code,ann_date,f_ann_date,end_date,report_type,comp_type,update_flag,total_revenue,revenue,total_cogs,operate_profit,total_profit,income_tax,n_income,n_income_attr_p,ebit,ebitda,rd_exp"
 outdir: "out"

--- a/src/tushare_a_fundamentals/transforms/deduplicate.py
+++ b/src/tushare_a_fundamentals/transforms/deduplicate.py
@@ -48,10 +48,14 @@ def mark_latest(
     gkeys = list(group_keys or ("ts_code", "end_date"))
     gkeys = [k for k in gkeys if k in out.columns]
     # stable sort to make cumcount deterministic across equal keys
-    out = out.sort_values(sort_cols, ascending=[False] * len(sort_cols), kind="mergesort")
+    out = out.sort_values(
+        sort_cols, ascending=[False] * len(sort_cols), kind="mergesort"
+    )
     out["_rank"] = out.groupby(gkeys).cumcount()
     out["is_latest"] = (out["_rank"] == 0).astype(int)
-    out = out.drop(columns=[c for c in ("_rt_pref", "_upd", "_rank") if c in out.columns])
+    out = out.drop(
+        columns=[c for c in ("_rt_pref", "_upd", "_rank") if c in out.columns]
+    )
     # restore original row order
     return out.sort_index()
 
@@ -65,5 +69,8 @@ def select_latest(
     if df.empty:
         return df.copy()
     flagged = mark_latest(df, group_keys=group_keys, extra_sort_keys=extra_sort_keys)
-    return flagged[flagged["is_latest"] == 1].drop(columns=["is_latest"]) if "is_latest" in flagged.columns else flagged
-
+    return (
+        flagged[flagged["is_latest"] == 1].drop(columns=["is_latest"])
+        if "is_latest" in flagged.columns
+        else flagged
+    )

--- a/src/tushare_a_fundamentals/writers/dataset_writer.py
+++ b/src/tushare_a_fundamentals/writers/dataset_writer.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence
+from typing import Sequence
 import uuid
 import time
 import pandas as pd
@@ -76,4 +75,3 @@ def write_partitioned_dataset(
         content.to_parquet(fpath, index=False)
         written.append(fpath)
     return written
-

--- a/tests/integration/test_cli_overrides.py
+++ b/tests/integration/test_cli_overrides.py
@@ -11,7 +11,7 @@ ENV = {**os.environ, "PYTHONPATH": os.path.join(ROOT, "src"), "TUSHARE_TOKEN": "
 
 
 def test_cli_overrides_config(tmp_path):
-    cfg = {"mode": "annual", "years": 1, "vip": True}
+    cfg = {"mode": "annual", "years": 1}
     cfg_path = tmp_path / "config.yml"
     cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
     code = subprocess.run(
@@ -26,6 +26,8 @@ def test_cli_overrides_config(tmp_path):
             "--quarters",
             "1",
             "--vip",
+            "--ts-code",
+            "000001.SZ",
         ],
         capture_output=True,
         text=True,

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -25,8 +25,8 @@ def test_error_no_token_env(monkeypatch):
     assert "缺少 TuShare token" in p.stderr
 
 
-def test_error_no_vip_no_ts_code(monkeypatch):
+def test_error_insufficient_credits(monkeypatch):
     monkeypatch.setenv("TUSHARE_TOKEN", "dummy")
-    p = run_cli("--mode", "annual", "--years", "1", "--no-vip")
+    p = run_cli("--mode", "annual", "--years", "1")
     assert p.returncode == 2
-    assert "未提供 --ts-code 且未启用 --vip" in p.stderr
+    assert "全市场批量需要至少 5000 积分" in p.stderr

--- a/tests/unit/test_credits.py
+++ b/tests/unit/test_credits.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from tushare_a_fundamentals.cli import _has_enough_credits
+
+pytestmark = pytest.mark.unit
+
+
+class DummyPro:
+    def __init__(self, df):
+        self._df = df
+
+    def user(self):
+        return self._df
+
+
+def test_has_enough_credits_true():
+    pro = DummyPro(pd.DataFrame({"到期积分": [3000, 2500]}))
+    assert _has_enough_credits(pro)
+
+
+def test_has_enough_credits_false():
+    pro = DummyPro(pd.DataFrame({"到期积分": [1000, 2000]}))
+    assert not _has_enough_credits(pro)


### PR DESCRIPTION
## Summary
- default to quarterly VIP mode and hide legacy `--vip`/`--mode` switches
- block bulk downloads unless the user has ≥5000 TuShare credits
- document streamlined commands and add credit-check unit and integration tests

## Testing
- `ruff check .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c582a3eaac83279f6e940221786c04