### PR TITLE
Expand test coverage and relax pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ pip install -e .
 uv sync
 ```
 
+### 运行测试
+
+```bash
+pytest
+# 如需覆盖率：pytest --cov=src --cov-report=term-missing
+```
+
 ### 运行 CLI
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ select = ["E", "F", "W", "C90"]
 max-complexity = 10
 
 [tool.pytest.ini_options]
-addopts = ["--cov=src", "--cov-report=term-missing"]
+# 默认不强制开启覆盖率插件，避免环境缺少 pytest-cov 时失败
+addopts = []
 markers = [
     "unit: unit tests",
     "integration: integration tests",

--- a/tests/integration/test_cli_ingest_build.py
+++ b/tests/integration/test_cli_ingest_build.py
@@ -1,0 +1,63 @@
+import sys
+import pandas as pd
+import pytest
+
+from tushare_a_fundamentals import cli as appmod
+
+pytestmark = pytest.mark.integration
+
+
+def test_cli_ingest_and_build(tmp_path, monkeypatch):
+    monkeypatch.setattr(appmod, "init_pro_api", lambda token: object())
+
+    def fake_ingest_single(pro, ts_code, periods, fields):
+        df = pd.DataFrame(
+            {
+                "ts_code": [ts_code],
+                "end_date": [periods[0]],
+                "ann_date": ["20240101"],
+                "f_ann_date": ["20240102"],
+                "report_type": [1],
+                "revenue": [100],
+            }
+        )
+        return df, df.copy(), df.copy()
+
+    monkeypatch.setattr(appmod, "_ingest_single", fake_ingest_single)
+
+    argv_ingest = [
+        "funda",
+        "ingest",
+        "--since",
+        "2023-01-01",
+        "--until",
+        "2023-12-31",
+        "--periods",
+        "quarterly",
+        "--ts-code",
+        "000001.SZ",
+        "--dataset-root",
+        str(tmp_path),
+        "--token",
+        "fake",
+    ]
+    monkeypatch.setattr(sys, "argv", argv_ingest)
+    appmod.main()
+    assert list((tmp_path / "dataset=fact_income_single").glob("**/*.parquet"))
+
+    out_dir = tmp_path / "out"
+    argv_build = [
+        "funda",
+        "build",
+        "--dataset-root",
+        str(tmp_path),
+        "--kinds",
+        "annual,quarterly",
+        "--out-format",
+        "csv",
+        "--out-dir",
+        str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", argv_build)
+    appmod.main()
+    assert (out_dir / "csv" / "income_annual.csv").exists()

--- a/tests/unit/test_dataset_writer.py
+++ b/tests/unit/test_dataset_writer.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tushare_a_fundamentals.writers.dataset_writer import write_partitioned_dataset
+
+pytestmark = pytest.mark.unit
+
+
+def _sample_df():
+    return pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20231231"],
+            "ann_date": ["20240101", "20240101"],
+            "f_ann_date": ["20240102", "20240102"],
+            "report_type": [1, 1],
+            "revenue": [10, 20],
+            "is_latest": [1, 0],
+        }
+    )
+
+
+def test_write_only_latest(tmp_path):
+    df = _sample_df()
+    paths = write_partitioned_dataset(
+        df,
+        tmp_path,
+        "income",
+        "year:end_date",
+        primary_key=["ts_code"],
+        version_by=["ann_date"],
+        only_latest=True,
+    )
+    assert len(paths) == 1
+    written = pd.read_parquet(paths[0])
+    assert written.shape[0] == 1
+    assert (Path(paths[0]).parent.parent.name) == "dataset=income"
+    assert Path(paths[0]).parent.name == "year=2023"
+
+
+def test_write_invalid_partition(tmp_path):
+    df = _sample_df()
+    with pytest.raises(ValueError):
+        write_partitioned_dataset(df, tmp_path, "income", "month:end_date")
+    with pytest.raises(KeyError):
+        write_partitioned_dataset(
+            df.drop(columns=["end_date"]), tmp_path, "income", "year:end_date"
+        )

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -33,3 +33,29 @@ def test_update_flag_break_tie():
     )
     got = appmod._select_latest(df)
     assert got.iloc[0]["update_flag"] == "Y"
+
+
+def test_mark_latest_extra_sort_keys():
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20231231"],
+            "ann_date": ["20240101", "20240101"],
+            "priority": [1, 2],
+        }
+    )
+    flagged = appmod._tx_mark_latest(df, extra_sort_keys=["priority"])
+    assert flagged.loc[flagged["is_latest"] == 1, "priority"].iloc[0] == 2
+
+
+def test_mark_latest_custom_group_keys():
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20230630"],
+            "ann_date": ["20240101", "20230801"],
+        }
+    )
+    flagged = appmod._tx_mark_latest(df, group_keys=["ts_code"])
+    assert flagged["is_latest"].sum() == 1
+    assert flagged.loc[flagged["is_latest"] == 1, "end_date"].iloc[0] == "20231231"

--- a/tests/unit/test_periods.py
+++ b/tests/unit/test_periods.py
@@ -14,3 +14,13 @@ def test_periods_quarters_count():
     periods = appmod.periods_by_quarters(6)
     assert len(periods) == 6
     assert periods == sorted(periods)
+
+
+@pytest.mark.parametrize("years", [0, -1])
+def test_periods_years_non_positive(years):
+    assert appmod.periods_for_mode_by_years(years, appmod.Mode.ANNUAL) == []
+
+
+@pytest.mark.parametrize("quarters", [0, -2])
+def test_periods_quarters_non_positive(quarters):
+    assert appmod.periods_by_quarters(quarters) == []


### PR DESCRIPTION
## Summary
- Allow running tests without pytest-cov by clearing default coverage options
- Document test command and optional coverage run in README
- Add edge case tests for period helpers and mark_latest
- Cover partitioned dataset writing and CLI ingest/build success paths

## Testing
- `ruff check .`
- `black --check tests/unit/test_dedup.py tests/unit/test_dataset_writer.py tests/unit/test_periods.py tests/integration/test_cli_ingest_build.py`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c58ab2d2848327ba1525e8b6638c01