### PR TITLE
feat: add coverage subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ funda --years 3
 funda --ts-code 600000.SH --years 5
 ```
 
+> 注意：以上顶层参数仅用于兼容旧版流程，推荐改用下文的 `ingest + build` 两步法。
+
 ### 两步法：ingest + build（推荐）
 
 目标是把“触网下载”和“离线构建导出”解耦：
@@ -104,6 +106,14 @@ funda build --kinds annual,quarterly,ttm \
   --out-format csv --out-dir out/csv \
   --dataset-root data_root
 ```
+
+3) coverage 可视化覆盖情况
+
+```bash
+funda coverage --dataset-root data_root --by ts_code
+```
+
+默认按 `ts_code` 输出股票×期末日覆盖矩阵，可使用 `--by period` 按期汇总。
 
 说明：
 - quarterly 直接来自单季事实表；

--- a/tests/integration/test_cli_ingest_build.py
+++ b/tests/integration/test_cli_ingest_build.py
@@ -7,7 +7,7 @@ from tushare_a_fundamentals import cli as appmod
 pytestmark = pytest.mark.integration
 
 
-def test_cli_ingest_and_build(tmp_path, monkeypatch):
+def test_cli_ingest_build_and_coverage(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(appmod, "init_pro_api", lambda token: object())
 
     def fake_ingest_single(pro, ts_code, periods, fields):
@@ -44,6 +44,20 @@ def test_cli_ingest_and_build(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", argv_ingest)
     appmod.main()
     assert list((tmp_path / "dataset=fact_income_single").glob("**/*.parquet"))
+
+    capsys.readouterr()
+    argv_cov = [
+        "funda",
+        "coverage",
+        "--dataset-root",
+        str(tmp_path),
+        "--by",
+        "ts_code",
+    ]
+    monkeypatch.setattr(sys, "argv", argv_cov)
+    appmod.main()
+    cov_out = capsys.readouterr().out
+    assert "000001.SZ" in cov_out
 
     out_dir = tmp_path / "out"
     argv_build = [

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from types import SimpleNamespace
+
+from tushare_a_fundamentals.cli import cmd_coverage
+
+
+def _prepare_dataset(root):
+    inv_dir = root / "dataset=inventory_income"
+    inv_dir.mkdir()
+    pd.DataFrame({"end_date": ["20231231", "20230930"]}).to_parquet(
+        inv_dir / "periods.parquet"
+    )
+    fact_dir = root / "dataset=fact_income_single"
+    fact_dir.mkdir()
+    pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20230930"],
+            "is_latest": [1, 1],
+        }
+    ).to_parquet(fact_dir / "data.parquet")
+    return root
+
+
+def test_cmd_coverage_by(tmp_path, capsys):
+    root = _prepare_dataset(tmp_path)
+
+    args = SimpleNamespace(dataset_root=str(root), by="ts_code")
+    cmd_coverage(args)
+    out = capsys.readouterr().out
+    assert "000001.SZ" in out
+
+    args = SimpleNamespace(dataset_root=str(root), by="period")
+    cmd_coverage(args)
+    out = capsys.readouterr().out
+    assert "20230930" in out


### PR DESCRIPTION
## Summary
- add `funda coverage` subcommand to inspect stock/period coverage
- document `coverage` usage and clarify top-level CLI is legacy
- test coverage workflow via integration test
- add unit test for `coverage` pivot output

## Testing
- `ruff check .`
- `black src/tushare_a_fundamentals/cli.py tests/integration/test_cli_ingest_build.py tests/unit/test_coverage.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c623aff8ac8327a6bc97f06d6e6854