### PR TITLE
fix: parse credit numbers with commas

### DIFF
--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -314,7 +314,11 @@ def _has_enough_credits(pro, required: int = 5000) -> bool:
         return False
     if "到期积分" not in df.columns:
         return False
-    total = pd.to_numeric(df["到期积分"], errors="coerce").sum()
+    # Convert to numeric, allowing values like "5,000"
+    credits = pd.to_numeric(
+        df["到期积分"].astype(str).str.replace(",", ""), errors="coerce"
+    )
+    total = credits.sum()
     return total >= required
 
 

--- a/tests/unit/test_credits.py
+++ b/tests/unit/test_credits.py
@@ -22,3 +22,8 @@ def test_has_enough_credits_true():
 def test_has_enough_credits_false():
     pro = DummyPro(pd.DataFrame({"到期积分": [1000, 2000]}))
     assert not _has_enough_credits(pro)
+
+
+def test_has_enough_credits_commas():
+    pro = DummyPro(pd.DataFrame({"到期积分": ["3,000", "2,500"]}))
+    assert _has_enough_credits(pro)


### PR DESCRIPTION
## Summary
- handle comma-separated credit values when checking total credits
- test credit check with comma-formatted numbers

## Testing
- `ruff check .`
- `black --check src/tushare_a_fundamentals/cli.py tests/unit/test_credits.py`
- `pytest -m unit`


------
https://chatgpt.com/codex/tasks/task_e_68c6272b141483279d707743359a484a