### PR TITLE
feat: add ticker alias and export column option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ funda download --help
 funda download
 ```
 
-单票下载并输出 TTM：
+单票下载（参数 `--ticker` 等同 TuShare ts_code，如 600000.SH）并输出 TTM：
 
 ```bash
-funda download --ts-code 600000.SH --years 5 --mode ttm
+funda download --ticker 600000.SH --years 5 --mode ttm
 ```
 
 按日期范围下载（自动按 mode 的粒度计算 period）：
@@ -86,13 +86,17 @@ funda download --since 2010-01-01 --until 2019-12-31
 
 * 提供 `--since`（可选 `--until`）时优先使用日期范围；
 
+* `--export-colname ts_code`：导出文件保留旧列名 `ts_code`；默认输出列为 `ticker`；
+
+兼容性：仍接受旧参数 `--ts-code`，使用时会打印弃用提示。
+
 #### 数据完整性检测/可视化覆盖情况
 
 ```bash
-funda coverage --dataset-root data_root --by ts_code
+funda coverage --dataset-root data_root --by ticker
 ```
 
-默认按 `ts_code` 输出股票×期末日覆盖矩阵，可使用 `--by period` 按期汇总。
+默认按 `ticker` 输出股票×期末日覆盖矩阵，可使用 `--by period` 按期汇总。
 
 说明：
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,7 @@ outdir: "out"
 prefix: "income"
 format: "parquet"
 skip_existing: false
+# export_colname: ticker  # or ts_code
 # token: "your_tushare_token"
 
 # Optional: Partitioned dataset writing

--- a/tests/integration/test_cli_ingest_build.py
+++ b/tests/integration/test_cli_ingest_build.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.integration
 
 def test_cli_download_build_and_coverage(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(appmod, "init_pro_api", lambda token: object())
+
     def fake_fetch_single_stock(pro, ts_code, years, quarters, mode, fields):
         df = pd.DataFrame(
             {
@@ -31,7 +32,7 @@ def test_cli_download_build_and_coverage(tmp_path, monkeypatch, capsys):
         "2023-01-01",
         "--until",
         "2023-12-31",
-        "--ts-code",
+        "--ticker",
         "000001.SZ",
         "--dataset-root",
         str(tmp_path),
@@ -49,7 +50,7 @@ def test_cli_download_build_and_coverage(tmp_path, monkeypatch, capsys):
         "--dataset-root",
         str(tmp_path),
         "--by",
-        "ts_code",
+        "ticker",
     ]
     monkeypatch.setattr(sys, "argv", argv_cov)
     appmod.main()
@@ -71,4 +72,7 @@ def test_cli_download_build_and_coverage(tmp_path, monkeypatch, capsys):
     ]
     monkeypatch.setattr(sys, "argv", argv_build)
     appmod.main()
-    assert (out_dir / "csv" / "income_annual.csv").exists()
+    annual_csv = out_dir / "csv" / "income_annual.csv"
+    assert annual_csv.exists()
+    df = pd.read_csv(annual_csv)
+    assert "ticker" in df.columns

--- a/tests/integration/test_cli_overrides.py
+++ b/tests/integration/test_cli_overrides.py
@@ -26,7 +26,7 @@ def test_cli_overrides_config(tmp_path):
             "--quarters",
             "1",
             "--vip",
-            "--ts-code",
+            "--ticker",
             "000001.SZ",
         ],
         capture_output=True,

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -25,7 +25,7 @@ def _prepare_dataset(root):
 def test_cmd_coverage_by(tmp_path, capsys):
     root = _prepare_dataset(tmp_path)
 
-    args = SimpleNamespace(dataset_root=str(root), by="ts_code")
+    args = SimpleNamespace(dataset_root=str(root), by="ticker")
     cmd_coverage(args)
     out = capsys.readouterr().out
     assert "000001.SZ" in out


### PR DESCRIPTION
## Summary
- add `--ticker` CLI option with `--ts-code` deprecation
- allow choosing export column name; default to `ticker`
- update coverage and docs to use `ticker`

## Testing
- `ruff check src/tushare_a_fundamentals/cli.py tests/unit/test_save_naming.py tests/integration/test_cli_ingest_build.py tests/integration/test_cli_overrides.py tests/unit/test_coverage.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c11c6c8483278bdafbe07cb4150a