### PR TITLE
feat: support selecting report types

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ funda download --since 2010-01-01 --until 2019-12-31
 * 提供 `--since`（可选 `--until`）时优先使用日期范围；
 
 * `--export-colname ts_code`：导出文件保留旧列名 `ts_code`；默认输出列为 `ticker`；
+* `--report-types 1,6`：指定报表 `report_type`（逗号分隔），默认仅下载 `1`（合并报表）；
 
 全量下载（建议）：
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,8 @@ fields: "ts_code,ann_date,f_ann_date,end_date,report_type,comp_type,update_flag,
 outdir: "out"
 prefix: "income"
 format: "parquet"
+# 默认仅下载合并报表（report_type=1），可填逗号分隔列表
+report_types: "1"
 # download 子命令默认采用增量补全（若已覆盖所需 period 则跳过）
 skip_existing: true
 # export_colname: ticker  # or ts_code

--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -8,6 +8,7 @@ from .common import (
     init_pro_api,
     load_yaml,
     merge_config,
+    parse_report_types,
 )
 
 
@@ -27,6 +28,11 @@ def parse_cli() -> argparse.Namespace:
     p.add_argument("--outdir", type=str)
     p.add_argument("--prefix", type=str)
     p.add_argument("--format", choices=["csv", "parquet"])
+    p.add_argument(
+        "--report-types",
+        type=str,
+        help="逗号分隔的 report_type 列表（默认 1）",
+    )
     p.add_argument(
         "--export-colname",
         choices=["ticker", "ts_code"],
@@ -87,6 +93,11 @@ def parse_cli() -> argparse.Namespace:
     sp_dl.add_argument("--prefix", type=str)
     sp_dl.add_argument("--format", choices=["csv", "parquet"])
     sp_dl.add_argument(
+        "--report-types",
+        type=str,
+        help="逗号分隔的 report_type 列表（默认 1）",
+    )
+    sp_dl.add_argument(
         "--export-colname",
         choices=["ticker", "ts_code"],
         default="ticker",
@@ -128,6 +139,7 @@ def main() -> None:
         "skip_existing": True,
         "token": None,
         "export_colname": "ticker",
+        "report_types": [1],
     }
     cli_overrides = {
         "years": args.years,
@@ -141,8 +153,10 @@ def main() -> None:
         "skip_existing": args.skip_existing,
         "token": args.token,
         "export_colname": args.export_colname,
+        "report_types": getattr(args, "report_types", None),
     }
     cfg = merge_config(cli_overrides, cfg_file, defaults)
+    cfg["report_types"] = parse_report_types(cfg.get("report_types"))
     if getattr(args, "force", False):
         cfg["skip_existing"] = False
     pro = init_pro_api(cfg.get("token"))

--- a/src/tushare_a_fundamentals/commands/download.py
+++ b/src/tushare_a_fundamentals/commands/download.py
@@ -8,6 +8,7 @@ from ..common import (
     init_pro_api,
     load_yaml,
     merge_config,
+    parse_report_types,
 )
 
 
@@ -25,6 +26,7 @@ def cmd_download(args: argparse.Namespace) -> None:
         "skip_existing": True,  # download 默认增量
         "token": None,
         "export_colname": "ticker",
+        "report_types": [1],
     }
     cli_overrides = {
         "years": getattr(args, "years", None),
@@ -37,8 +39,10 @@ def cmd_download(args: argparse.Namespace) -> None:
         "format": getattr(args, "format", None),
         "token": getattr(args, "token", None),
         "export_colname": getattr(args, "export_colname", None),
+        "report_types": getattr(args, "report_types", None),
     }
     cfg = merge_config(cli_overrides, cfg_file, defaults)
+    cfg["report_types"] = parse_report_types(cfg.get("report_types"))
     if getattr(args, "force", False):
         cfg["skip_existing"] = False
     pro = init_pro_api(cfg.get("token"))

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -63,3 +63,16 @@ def test_mark_latest_custom_group_keys():
     flagged = _tx_mark_latest(df, group_keys=["ts_code"])
     assert flagged["is_latest"].sum() == 1
     assert flagged.loc[flagged["is_latest"] == 1, "end_date"].iloc[0] == "20231231"
+
+
+def test_select_latest_with_report_type_grouping():
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20231231"],
+            "report_type": [1, 6],
+            "ann_date": ["20240101", "20240102"],
+        }
+    )
+    got = _select_latest(df, group_keys=("ts_code", "end_date", "report_type"))
+    assert set(got["report_type"]) == {1, 6}

--- a/tests/unit/test_fetch_income_bulk.py
+++ b/tests/unit/test_fetch_income_bulk.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+
+from tushare_a_fundamentals.common import fetch_income_bulk
+
+pytestmark = pytest.mark.unit
+
+
+class DummyPro:
+    def __init__(self):
+        self.calls = []
+
+    def income_vip(self, fields: str, period: str, report_type: int):
+        self.calls.append(report_type)
+        return pd.DataFrame(
+            {
+                "ts_code": ["000001.SZ"],
+                "end_date": [period],
+                "report_type": [report_type],
+                "ann_date": ["20240101"],
+                "f_ann_date": ["20240101"],
+            }
+        )
+
+
+def test_fetch_income_bulk_multiple_report_types():
+    pro = DummyPro()
+    periods = ["20231231"]
+    fields = "ts_code,ann_date,f_ann_date,end_date,report_type"
+    tables = fetch_income_bulk(
+        pro, periods=periods, mode="quarterly", fields=fields, report_types=[1, 6]
+    )
+    assert pro.calls == [1, 6]
+    assert set(tables["raw"]["report_type"]) == {1, 6}

--- a/tests/unit/test_report_types.py
+++ b/tests/unit/test_report_types.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tushare_a_fundamentals.common import parse_report_types
+
+pytestmark = pytest.mark.unit
+
+
+def test_parse_report_types():
+    assert parse_report_types(None) == [1]
+    assert parse_report_types("1,6") == [1, 6]
+    assert parse_report_types(3) == [3]


### PR DESCRIPTION
## Summary
- allow choosing report types via `--report-types` and config
- fetch multiple report types and dedupe per report type
- cover new report type parsing and fetching with unit tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c76beb20408327acfe88858ca1a3e1