### PR TITLE
feat: default coverage and export to last 10 years

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ funda download --since 2010-01-01 --until 2019-12-31
 #### 数据完整性检测/可视化覆盖情况
 
 ```bash
-funda coverage --dataset-root data_root --by ticker
+funda coverage --by ticker
 ```
 
-默认按 `ticker` 输出股票×期末日覆盖矩阵，可使用 `--by period` 按期汇总。
+默认按 `ticker` 输出股票×期末日覆盖矩阵，可使用 `--by period` 按期汇总。数据集根目录默认为 `out`，可用 `--dataset-root` 指定，`--years` 可调整年份窗口（默认近 10 年）。
 
 说明：
 
@@ -140,11 +140,12 @@ funda coverage --dataset-root data_root --by ticker
 随后可用 `export` 构建 annual / single / cumulative 导出：
 
 ```bash
-funda export --kinds annual,single \
-  --annual-strategy cumulative \
-  --out-format csv --out-dir out/csv \
-  --dataset-root data_root
+funda export --kinds annual,single \\
+  --annual-strategy cumulative \\
+  --out-format csv --out-dir out/csv
 ```
+
+同样默认读取 `out` 目录下的数据集，并导出最近 10 年，可通过 `--dataset-root` 或 `--years` 参数微调。
 
 ## 开发约定
 

--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -48,7 +48,10 @@ def parse_cli() -> argparse.Namespace:
     sp_exp = sub.add_parser(
         "export", help="由本地事实表构建 annual/single/cumulative 导出"
     )
-    sp_exp.add_argument("--dataset-root", type=str, required=True)
+    sp_exp.add_argument(
+        "--dataset-root", type=str, default="out", help="数据集根目录（默认 out）"
+    )
+    sp_exp.add_argument("--years", type=int, default=10, help="近几年（默认 10）")
     sp_exp.add_argument(
         "--export-colname",
         choices=["ticker", "ts_code"],
@@ -72,7 +75,10 @@ def parse_cli() -> argparse.Namespace:
     sp_exp.add_argument("--prefix", type=str, default="income")
 
     sp_cov = sub.add_parser("coverage", help="盘点已覆盖的股票×期末日")
-    sp_cov.add_argument("--dataset-root", type=str, required=True)
+    sp_cov.add_argument(
+        "--dataset-root", type=str, default="out", help="数据集根目录（默认 out）"
+    )
+    sp_cov.add_argument("--years", type=int, default=10, help="近几年（默认 10）")
     sp_cov.add_argument(
         "--by",
         choices=["ticker", "ts_code", "period"],

--- a/src/tushare_a_fundamentals/commands/export.py
+++ b/src/tushare_a_fundamentals/commands/export.py
@@ -9,6 +9,7 @@ from ..common import FLOW_FIELDS, _diff_to_single, _export_tables, _load_dataset
 
 def cmd_export(args: argparse.Namespace) -> None:
     root = args.dataset_root
+    years = getattr(args, "years", 10)
     kinds = [s.strip() for s in args.kinds.split(",") if s.strip()]
     out_fmt = args.out_format
     out_dir = args.out_dir
@@ -17,6 +18,10 @@ def cmd_export(args: argparse.Namespace) -> None:
     cum = _load_dataset(root, "fact_income_cum")
     if "is_latest" in cum.columns:
         cum = cum[cum["is_latest"] == 1]
+    periods = sorted(cum["end_date"].astype(str).unique())
+    if years is not None:
+        keep = set(periods[-years * 4 :])
+        cum = cum[cum["end_date"].astype(str).isin(keep)]
 
     built: Dict[str, pd.DataFrame] = {}
 

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -35,3 +35,30 @@ def test_cmd_coverage_by(tmp_path, capsys):
     cmd_coverage(args)
     out = capsys.readouterr().out
     assert "20230930" in out
+
+
+def test_cmd_coverage_years(tmp_path, capsys):
+    inv_dir = tmp_path / "dataset=inventory_income"
+    inv_dir.mkdir()
+    periods = [
+        "20211231",
+        "20220331",
+        "20220630",
+        "20220930",
+        "20221231",
+    ]
+    pd.DataFrame({"end_date": periods}).to_parquet(inv_dir / "periods.parquet")
+    fact_dir = tmp_path / "dataset=fact_income_cum"
+    fact_dir.mkdir()
+    pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ"] * len(periods),
+            "end_date": periods,
+            "is_latest": [1] * len(periods),
+        }
+    ).to_parquet(fact_dir / "data.parquet")
+    args = SimpleNamespace(dataset_root=str(tmp_path), by="period", years=1)
+    cmd_coverage(args)
+    out = capsys.readouterr().out
+    assert "20211231" not in out
+    assert "20221231" in out

--- a/tests/unit/test_export_cmd.py
+++ b/tests/unit/test_export_cmd.py
@@ -42,3 +42,44 @@ def test_cmd_export_generates_single_and_cumulative(monkeypatch):
     q1, q2 = single_df["total_revenue"].tolist()
     assert q1 == 10.0
     assert q2 == 20.0
+
+
+def test_cmd_export_years_filter(monkeypatch):
+    periods = [
+        "20211231",
+        "20220331",
+        "20220630",
+        "20220930",
+        "20221231",
+    ]
+    cum = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ"] * len(periods),
+            "end_date": periods,
+            "total_revenue": list(range(len(periods))),
+        }
+    )
+
+    monkeypatch.setattr(expmod, "_load_dataset", lambda root, name: cum)
+    saved = {}
+
+    def fake_export_tables(built, out_dir, prefix, out_fmt, colname):
+        saved.update(built)
+
+    monkeypatch.setattr(expmod, "_export_tables", fake_export_tables)
+
+    args = argparse.Namespace(
+        dataset_root="root",
+        kinds="cumulative",
+        out_format="csv",
+        out_dir="out",
+        prefix="income",
+        export_colname="ticker",
+        annual_strategy="cumulative",
+        years=1,
+    )
+
+    expmod.cmd_export(args)
+
+    cum_df = saved["cumulative"]
+    assert set(cum_df["end_date"].astype(str)) == set(periods[-4:])


### PR DESCRIPTION
## Summary
- allow `funda coverage` and `funda export` to run without extra args
- add `--years` option to limit periods (default 10)
- document defaults and update tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d409013c832782077acd7fe38bbf