### PR TITLE
feat: integrate warehouse build into download

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## 运行原理/快速运行指南
 
-1. 下载所需数据，通过指令：`funda download`
+1. 下载并构建所需数据，通过指令：`funda download`
 
 2. （可选但建议）检查下载数据是否完整：`funda coverage`
 
@@ -101,6 +101,9 @@ funda download --since 2010-01-01 --until 2019-12-31
 * `--export-colname ts_code`：导出文件保留旧列名 `ts_code`；默认输出列为 `ticker`；
 
 * `--report-types 1,6`：指定报表 `report_type`（逗号分隔），默认仅下载 `1`（合并报表）；
+* `--raw-only`：只下载 raw，不构建数仓；
+* `--build-only`：跳过下载，仅由已有 raw 构建数仓；
+* 默认会依据披露截止日裁掉未来季度，如需强制包含可加 `--allow-future`；
 
 全量下载（建议）：
 
@@ -114,7 +117,7 @@ funda download --since 2010-01-01 --until 2019-12-31
     funda download --years 30
     ```
 
-说明：下载口径固定为“按季度期末日的累计（YTD）值”，当前版本仅导出原始去重表 `raw`。
+说明：下载口径固定为“按季度期末日的累计（YTD）值”，默认还会生成 `dataset=inventory_income` 与 `dataset=fact_income_cum` 两套数仓数据；仅需原始去重表时可追加 `--raw-only`。
 
 #### 数据完整性检测/可视化覆盖情况
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,5 +9,6 @@ format: "parquet"
 report_types: "1"
 # The 'download' subcommand uses incremental completion by default (skips if the required period is already covered).
 skip_existing: true
+# allow_future: false  # 设为 true 可拉取尚未披露的未来季度
 # export_colname: ticker
 # token: "your_tushare_token"

--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -115,6 +115,22 @@ def parse_cli() -> argparse.Namespace:
         action="store_true",
         help="强制重新下载并覆盖已有文件（忽略增量跳过）",
     )
+    flag_group = sp_dl.add_mutually_exclusive_group()
+    flag_group.add_argument(
+        "--raw-only",
+        action="store_true",
+        help="仅下载 raw，不构建数仓",
+    )
+    flag_group.add_argument(
+        "--build-only",
+        action="store_true",
+        help="跳过下载，仅由 raw 构建数仓",
+    )
+    sp_dl.add_argument(
+        "--allow-future",
+        action="store_true",
+        help="允许请求尚未披露的未来季度",
+    )
     return p.parse_args()
 
 

--- a/src/tushare_a_fundamentals/commands/download.py
+++ b/src/tushare_a_fundamentals/commands/download.py
@@ -1,9 +1,11 @@
 import argparse
+import sys
 
 from ..common import (
     DEFAULT_FIELDS,
     _check_parquet_dependency,
     _run_bulk_mode,
+    build_datasets_from_raw,
     eprint,
     init_pro_api,
     load_yaml,
@@ -27,6 +29,7 @@ def cmd_download(args: argparse.Namespace) -> None:
         "token": None,
         "export_colname": "ticker",
         "report_types": [1],
+        "allow_future": False,
     }
     cli_overrides = {
         "years": getattr(args, "years", None),
@@ -40,17 +43,26 @@ def cmd_download(args: argparse.Namespace) -> None:
         "token": getattr(args, "token", None),
         "export_colname": getattr(args, "export_colname", None),
         "report_types": getattr(args, "report_types", None),
+        "allow_future": getattr(args, "allow_future", None),
     }
     cfg = merge_config(cli_overrides, cfg_file, defaults)
     cfg["report_types"] = parse_report_types(cfg.get("report_types"))
+    raw_only = getattr(args, "raw_only", False)
+    build_only = getattr(args, "build_only", False)
+    if raw_only and build_only:
+        eprint("错误：--raw-only 与 --build-only 互斥")
+        sys.exit(2)
     if getattr(args, "force", False):
         cfg["skip_existing"] = False
-    pro = init_pro_api(cfg.get("token"))
-    fields = cfg["fields"]
-    fmt = cfg["format"]
-    if fmt == "parquet" and not _check_parquet_dependency():
-        eprint("警告：缺少 pyarrow 或 fastparquet，已回退到 csv 格式")
-        fmt = "csv"
     outdir = cfg["outdir"]
     prefix = cfg["prefix"]
-    _run_bulk_mode(pro, cfg, fields, fmt, outdir, prefix)
+    if not build_only:
+        pro = init_pro_api(cfg.get("token"))
+        fields = cfg["fields"]
+        fmt = cfg["format"]
+        if fmt == "parquet" and not _check_parquet_dependency():
+            eprint("警告：缺少 pyarrow 或 fastparquet，已回退到 csv 格式")
+            fmt = "csv"
+        _run_bulk_mode(pro, cfg, fields, fmt, outdir, prefix)
+    if not raw_only:
+        build_datasets_from_raw(outdir, prefix)

--- a/tests/unit/test_build_datasets.py
+++ b/tests/unit/test_build_datasets.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from tushare_a_fundamentals.common import build_datasets_from_raw
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_datasets_from_raw(tmp_path):
+    raw_dir = tmp_path / "parquet"
+    raw_dir.mkdir()
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20231231", "20230930"],
+            "report_type": [1, 6, 1],
+            "update_flag": ["N", "N", "N"],
+        }
+    )
+    df.to_parquet(raw_dir / "income_vip_quarterly_raw.parquet", index=False)
+    build_datasets_from_raw(str(tmp_path), "income")
+    inv = pd.read_parquet(tmp_path / "dataset=inventory_income" / "periods.parquet")
+    assert inv["end_date"].tolist() == ["20230930", "20231231"]
+    fact_file = tmp_path / "dataset=fact_income_cum" / "year=2023" / "part.parquet"
+    fact = pd.read_parquet(fact_file)
+    assert set(fact["end_date"]) == {"20230930", "20231231"}
+    assert (fact["is_latest"] == 1).all()

--- a/tests/unit/test_last_publishable_period.py
+++ b/tests/unit/test_last_publishable_period.py
@@ -1,0 +1,25 @@
+from datetime import date
+
+import pytest
+
+from tushare_a_fundamentals.common import _periods_from_cfg, last_publishable_period
+
+pytestmark = pytest.mark.unit
+
+
+def test_last_publishable_period():
+    assert last_publishable_period(date(2025, 9, 15)) == "20250630"
+    assert last_publishable_period(date(2025, 11, 1)) == "20250930"
+
+
+def test_periods_from_cfg_trim_future(monkeypatch):
+    monkeypatch.setattr(
+        "tushare_a_fundamentals.common.last_publishable_period",
+        lambda today: "20250630",
+    )
+    cfg = {"since": "2025-01-01", "until": "2025-12-31"}
+    periods = _periods_from_cfg(cfg)
+    assert periods == ["20250331", "20250630"]
+    cfg["allow_future"] = True
+    periods = _periods_from_cfg(cfg)
+    assert periods == ["20250331", "20250630", "20250930", "20251231"]


### PR DESCRIPTION
## Summary
- build inventory_income and fact_income_cum datasets after downloading
- trim periods to the latest publishable quarter with optional `--allow-future`
- add `--raw-only` and `--build-only` flags

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c822cd8de4832786ba5d83a43cd097