### PR TITLE
feat: export CSV snapshots from download

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,5 +11,13 @@ report_types: "1"
 # Set skip_existing to true to disable rolling refresh (only fetch missing combos).
 skip_existing: false
 recent_quarters: 8
+# Derived export controls (download -> parquet snapshot -> CSV export)
+export_enabled: true
+export_out_format: "csv"
+export_out_dir: null  # default to <outdir>/<format>
+export_kinds: "annual,single,cumulative"
+export_annual_strategy: "cumulative"
+# export_years: 10
+# export_strict: false
 # allow_future: false  # 设为 true 可拉取尚未披露的未来季度
 # token: "your_tushare_token"

--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -134,6 +134,52 @@ def parse_cli() -> argparse.Namespace:
         action="store_true",
         help="允许请求尚未披露的未来季度",
     )
+    sp_dl.add_argument(
+        "--no-export",
+        action="store_true",
+        dest="no_export",
+        help="仅写 raw/parquet 数仓，不导出派生 CSV",
+    )
+    sp_dl.add_argument(
+        "--export", action="store_true", dest="export_enabled"
+    )
+    sp_dl.set_defaults(export_enabled=None)
+    sp_dl.add_argument(
+        "--export-out-dir",
+        dest="export_out_dir",
+        type=str,
+        help="导出目录（默认与 outdir 下格式目录一致）",
+    )
+    sp_dl.add_argument(
+        "--export-format",
+        dest="export_out_format",
+        choices=["csv", "parquet"],
+        help="导出格式（默认 csv）",
+    )
+    sp_dl.add_argument(
+        "--export-kinds",
+        dest="export_kinds",
+        type=str,
+        help="导出口径（默认 annual,single,cumulative）",
+    )
+    sp_dl.add_argument(
+        "--export-annual-strategy",
+        dest="export_annual_strategy",
+        choices=["cumulative", "sum4"],
+        help="年度导出策略（默认 cumulative）",
+    )
+    sp_dl.add_argument(
+        "--export-years",
+        dest="export_years",
+        type=int,
+        help="导出最近 N 年（默认沿用下载窗口，未指定则导出全部）",
+    )
+    sp_dl.add_argument(
+        "--strict-export",
+        dest="export_strict",
+        action="store_true",
+        help="导出失败时视为错误退出（默认仅警告）",
+    )
     return p.parse_args()
 
 

--- a/src/tushare_a_fundamentals/commands/download.py
+++ b/src/tushare_a_fundamentals/commands/download.py
@@ -1,5 +1,7 @@
 import argparse
+import os
 import sys
+from argparse import Namespace
 
 from ..common import (
     DEFAULT_FIELDS,
@@ -12,11 +14,11 @@ from ..common import (
     merge_config,
     parse_report_types,
 )
+from .export import cmd_export
 
 
-def cmd_download(args: argparse.Namespace) -> None:
-    cfg_file = load_yaml(getattr(args, "config", None))
-    defaults = {
+def _download_defaults() -> dict:
+    return {
         "years": 10,
         "quarters": None,
         "since": None,
@@ -30,8 +32,18 @@ def cmd_download(args: argparse.Namespace) -> None:
         "report_types": [1],
         "allow_future": False,
         "recent_quarters": 8,
+        "export_enabled": True,
+        "export_out_dir": None,
+        "export_out_format": "csv",
+        "export_kinds": "annual,single,cumulative",
+        "export_annual_strategy": "cumulative",
+        "export_years": None,
+        "export_strict": False,
     }
-    cli_overrides = {
+
+
+def _collect_cli_overrides(args: argparse.Namespace) -> dict:
+    overrides = {
         "years": getattr(args, "years", None),
         "quarters": getattr(args, "quarters", None),
         "since": getattr(args, "since", None),
@@ -44,7 +56,73 @@ def cmd_download(args: argparse.Namespace) -> None:
         "report_types": getattr(args, "report_types", None),
         "allow_future": getattr(args, "allow_future", None),
         "recent_quarters": getattr(args, "recent_quarters", None),
+        "export_out_dir": getattr(args, "export_out_dir", None),
+        "export_out_format": getattr(args, "export_out_format", None),
+        "export_kinds": getattr(args, "export_kinds", None),
+        "export_annual_strategy": getattr(args, "export_annual_strategy", None),
+        "export_years": getattr(args, "export_years", None),
+        "export_strict": getattr(args, "export_strict", None),
     }
+    if getattr(args, "export_enabled", None) is not None:
+        overrides["export_enabled"] = getattr(args, "export_enabled")
+    if getattr(args, "no_export", False):
+        overrides["export_enabled"] = False
+    return overrides
+
+
+def _resolve_raw_format(cfg: dict) -> str:
+    fmt = cfg.get("format", "parquet")
+    if fmt == "parquet" and not _check_parquet_dependency():
+        eprint("警告：缺少 pyarrow 或 fastparquet，已回退到 csv 格式")
+        return "csv"
+    return fmt
+
+
+def _build_export_args(cfg: dict, outdir: str, prefix: str) -> Namespace | None:
+    if not cfg.get("export_enabled", True):
+        return None
+    export_out_format = (cfg.get("export_out_format") or "csv").lower()
+    export_out_dir = cfg.get("export_out_dir") or os.path.join(outdir, export_out_format)
+    export_kinds_cfg = cfg.get("export_kinds")
+    if isinstance(export_kinds_cfg, (list, tuple, set)):
+        export_kinds = ",".join(
+            str(k).strip() for k in export_kinds_cfg if str(k).strip()
+        )
+    elif export_kinds_cfg is None:
+        export_kinds = "annual,single,cumulative"
+    else:
+        export_kinds = str(export_kinds_cfg)
+    export_years = cfg.get("export_years")
+    if export_years is None:
+        export_years = cfg.get("years")
+    return Namespace(
+        dataset_root=outdir,
+        years=export_years,
+        kinds=export_kinds,
+        annual_strategy=cfg.get("export_annual_strategy", "cumulative"),
+        out_format=export_out_format,
+        out_dir=export_out_dir,
+        prefix=prefix,
+    )
+
+
+def _run_export(export_args: Namespace, strict: bool | None) -> None:
+    try:
+        cmd_export(export_args)
+    except SystemExit as exc:
+        if strict:
+            raise
+        eprint(f"警告：导出失败（已保留 parquet）：{exc}")
+    except Exception as exc:  # pragma: no cover - defensive guard
+        eprint(f"警告：导出失败（已保留 parquet）：{exc}")
+        if strict:
+            raise
+
+
+def cmd_download(args: argparse.Namespace) -> None:
+    cfg_file = load_yaml(getattr(args, "config", None))
+    defaults = _download_defaults()
+    cli_overrides = _collect_cli_overrides(args)
     cfg = merge_config(cli_overrides, cfg_file, defaults)
     cfg["report_types"] = parse_report_types(cfg.get("report_types"))
     raw_only = getattr(args, "raw_only", False)
@@ -56,13 +134,15 @@ def cmd_download(args: argparse.Namespace) -> None:
         cfg["skip_existing"] = False
     outdir = cfg["outdir"]
     prefix = cfg["prefix"]
+    raw_fmt = cfg.get("format", "parquet")
     if not build_only:
         pro = init_pro_api(cfg.get("token"))
         fields = cfg["fields"]
-        fmt = cfg["format"]
-        if fmt == "parquet" and not _check_parquet_dependency():
-            eprint("警告：缺少 pyarrow 或 fastparquet，已回退到 csv 格式")
-            fmt = "csv"
-        _run_bulk_mode(pro, cfg, fields, fmt, outdir, prefix)
+        raw_fmt = _resolve_raw_format(cfg)
+        _run_bulk_mode(pro, cfg, fields, raw_fmt, outdir, prefix)
+    built = False
     if not raw_only:
-        build_datasets_from_raw(outdir, prefix)
+        built = build_datasets_from_raw(outdir, prefix, raw_format=raw_fmt)
+    export_args = _build_export_args(cfg, outdir, prefix) if built else None
+    if export_args is not None:
+        _run_export(export_args, strict=cfg.get("export_strict"))

--- a/tests/unit/test_build_datasets.py
+++ b/tests/unit/test_build_datasets.py
@@ -18,10 +18,30 @@ def test_build_datasets_from_raw(tmp_path):
         }
     )
     df.to_parquet(raw_dir / "income_vip_quarterly_raw.parquet", index=False)
-    build_datasets_from_raw(str(tmp_path), "income")
+    built = build_datasets_from_raw(str(tmp_path), "income")
+    assert built is True
     inv = pd.read_parquet(tmp_path / "dataset=inventory_income" / "periods.parquet")
     assert inv["end_date"].tolist() == ["20230930", "20231231"]
     fact_file = tmp_path / "dataset=fact_income_cum" / "year=2023" / "part.parquet"
     fact = pd.read_parquet(fact_file)
     assert set(fact["end_date"]) == {"20230930", "20231231"}
     assert (fact["is_latest"] == 1).all()
+
+
+def test_build_datasets_from_csv(tmp_path):
+    raw_dir = tmp_path / "csv"
+    raw_dir.mkdir()
+    df = pd.DataFrame(
+        {
+            "ts_code": ["000001.SZ", "000001.SZ"],
+            "end_date": ["20231231", "20230930"],
+            "report_type": [1, 1],
+            "update_flag": ["N", "N"],
+        }
+    )
+    df.to_csv(raw_dir / "income_vip_quarterly_raw.csv", index=False)
+    built = build_datasets_from_raw(str(tmp_path), "income")
+    assert built is True
+    fact_file = tmp_path / "dataset=fact_income_cum" / "year=2023" / "part.parquet"
+    fact = pd.read_parquet(fact_file)
+    assert fact["is_latest"].tolist() == [1, 1]

--- a/tests/unit/test_credits.py
+++ b/tests/unit/test_credits.py
@@ -27,3 +27,8 @@ def test_has_enough_credits_false():
 def test_has_enough_credits_commas():
     pro = DummyPro(pd.DataFrame({"到期积分": ["3,000", "2,500"]}))
     assert _has_enough_credits(pro)
+
+
+def test_has_enough_credits_boundary():
+    pro = DummyPro(pd.DataFrame({"到期积分": [4999.999, 0.0]}))
+    assert _has_enough_credits(pro)


### PR DESCRIPTION
## Summary
- run `funda download` as a full parquet+CSV pipeline with helper functions, config defaults, and CLI switches for export control
- document the new defaults and knobs in the README and sample config
- harden raw dataset rebuilding to read either parquet or CSV, improve credit threshold handling, and extend unit coverage for CSV builds and boundary credits

## Testing
- `ruff check .` *(fails: C901 on pre-existing high-complexity helpers)*
- `pytest` *(fails: environment lacks pandas/yaml and package install)*

------
https://chatgpt.com/codex/tasks/task_e_68c92000dd808327be379c369c93b91c