### PR TITLE
Improve downloader deduplication and state management

### DIFF
--- a/src/tushare_a_fundamentals/commands/download.py
+++ b/src/tushare_a_fundamentals/commands/download.py
@@ -163,6 +163,7 @@ def cmd_download(args: argparse.Namespace) -> None:
             use_vip=use_vip,
             max_per_minute=max_per_minute,
             state_path=cfg.get("state_path"),
+            allow_future=bool(cfg.get("allow_future")),
         )
         downloader.run(
             dataset_requests,


### PR DESCRIPTION
## Summary
- add dataset-specific dedupe keys and rewrite parquet writing to merge partitions with latest rows only
- track quarterly state per report/type combination, defer updates until a successful write, and bound future periods via the `allow_future` flag
- add retrying plus defensive pagination for API calls and expose the `allow_future` switch through the CLI downloader

## Testing
- pytest -m unit *(fails: missing pandas/yaml/tushare_a_fundamentals dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d699edab0c832797854e487bdd9ee2