### PR TITLE
Fix credit threshold rounding tolerance

### DIFF
--- a/src/tushare_a_fundamentals/common.py
+++ b/src/tushare_a_fundamentals/common.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 import os
 import sys
 import time
@@ -285,7 +286,12 @@ def _has_enough_credits(pro, required: int = 5000) -> bool:
     total = _available_credits(pro)
     if total is None:
         return False
-    return float(total) + 1e-6 >= float(required)
+    total_f = float(total)
+    required_f = float(required)
+    if total_f >= required_f:
+        return True
+    # Allow small rounding errors from the TuShare API (values like 4999.999).
+    return math.isclose(total_f, required_f, rel_tol=0.0, abs_tol=1e-3)
 
 
 def _concat_non_empty(dfs: List[pd.DataFrame]) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- allow `_has_enough_credits` to tolerate tiny rounding errors in TuShare responses
- import `math` to support the revised threshold comparison logic

## Testing
- pytest tests/unit/test_credits.py::test_has_enough_credits_boundary *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a2b91994832785d7c98b624037d8