### PR TITLE
fix: preserve schema in concat helper

### DIFF
--- a/src/tushare_a_fundamentals/common.py
+++ b/src/tushare_a_fundamentals/common.py
@@ -485,13 +485,13 @@ def _concat_non_empty(dfs: List[pd.DataFrame]) -> pd.DataFrame:
     for df in dfs:
         if df is None or not isinstance(df, pd.DataFrame):
             continue
-        df = df.dropna(axis=1, how="all")
-        if df.shape[1] == 0:
-            continue
         for col in df.columns:
             if col not in seen_set:
                 seen_set.add(col)
                 seen_order.append(col)
+        df = df.dropna(axis=1, how="all")
+        if df.shape[1] == 0:
+            continue
         if df.shape[0] == 0:
             continue
         if not df.notna().to_numpy().any():


### PR DESCRIPTION
## Summary
- ensure `_concat_non_empty` records columns before removing all-NA dataframes so schema order is retained for empty concatenations

## Testing
- pytest tests/unit/test_concat_non_empty.py::test_concat_non_empty_preserves_schema_from_all_na *(fails: pandas not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce4d8e8f48327bd76d29289a5a964