### PR TITLE
Handle insufficient TuShare credits in multi-dataset downloads

### DIFF
--- a/src/tushare_a_fundamentals/commands/download.py
+++ b/src/tushare_a_fundamentals/commands/download.py
@@ -12,6 +12,7 @@ from ..common import (
     _export_tables,
     _periods_from_cfg,
     build_income_export_tables,
+    ensure_enough_credits,
     ensure_ts_code,
     eprint,
     init_pro_api,
@@ -410,6 +411,8 @@ def _run_multi_dataset_flow(
     use_vip: bool,
 ) -> None:
     pro = init_pro_api(cfg.get("token"))
+    if use_vip:
+        ensure_enough_credits(pro)
     data_dir = cfg.get("data_dir") or "data"
     max_per_minute = cfg.get("max_per_minute")
     if max_per_minute is None:

--- a/src/tushare_a_fundamentals/common.py
+++ b/src/tushare_a_fundamentals/common.py
@@ -600,6 +600,20 @@ def _has_enough_credits(pro, required: int = 5000) -> bool:
     return 0 <= (required_d - total_d) <= Decimal("0.001")
 
 
+def ensure_enough_credits(pro, required: int = 5000) -> None:
+    """Exit with an error message when available credits are insufficient."""
+
+    if _has_enough_credits(pro, required=required):
+        return
+    total = _available_credits(pro)
+    detected = "0" if total is None else repr(total)
+    eprint(
+        "错误：全市场批量需要至少 "
+        f"{required} 积分。（检测到总积分：{detected}）"
+    )
+    sys.exit(2)
+
+
 def _concat_non_empty(dfs: List[pd.DataFrame]) -> pd.DataFrame:
     """Concatenate DataFrames after dropping empty or all-NA ones."""
 
@@ -1240,11 +1254,7 @@ def build_income_export_tables(
 def _run_bulk_mode(
     pro, cfg: dict, fields: str, fmt: str, outdir: str, prefix: str
 ) -> None:
-    if not _has_enough_credits(pro):
-        total = _available_credits(pro)
-        detected = "0" if total is None else repr(total)
-        eprint(f"错误：全市场批量需要至少 5000 积分。（检测到总积分：{detected}）")
-        sys.exit(2)
+    ensure_enough_credits(pro)
     periods = _periods_from_cfg(cfg)
     base = f"{prefix}_vip_quarterly"
     report_types = cfg.get("report_types") or [1]


### PR DESCRIPTION
## Summary
- add a reusable helper that prints the existing insufficient credits error and exits
- call the helper from both the bulk mode and multi-dataset download flow so the CLI fails early when credits are missing

## Testing
- pytest tests/integration/test_errors.py::test_error_insufficient_credits


------
https://chatgpt.com/codex/tasks/task_e_68de803285b083279e060ac81aea7f5e