### PR TITLE
Auto-detect VIP tokens and route VIP calls safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@
 TUSHARE_TOKEN=your_tushare_token_here
 TUSHARE_TOKEN_2="replace-with-your-second-tushare-pro-token"
 
+# Optional: explicitly declare VIP tokens (comma-separated) when multiple tokens exist.
+# When omitted the CLI will try to detect which tokens have ≥5000积分 automatically.
+# TUSHARE_VIP_TOKENS=token_with_5000_points,another_token
+
+# Optional: disable auto detection (set to false/0). When disabled and VIP tokens are
+# not specified, only the first token participates in VIP calls.
+# TUSHARE_DETECT_VIP=true
+
 # Optional: legacy/alternative name. If set and TUSHARE_TOKEN is empty,
 # the CLI will map this to TUSHARE_TOKEN automatically.
 # TUSHARE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -129,9 +129,15 @@ recent_quarters: 4          # 刷新最近的季度数 (建议 2-4 覆盖常见�
 
     * `TUSHARE_TOKEN_2`：如需配置第二个 TuShare 凭证以实现轮询调用，可选填。
 
+    * `TUSHARE_VIP_TOKENS`：可选。逗号分隔的 token 列表，用于显式指定哪些凭证用于 VIP 接口轮询。未设置时将根据积分（≥5000）自动识别。
+
+    * `TUSHARE_DETECT_VIP`：可选。设为 `false`/`0` 可禁用自动识别 VIP 凭证；禁用后若未指定 `TUSHARE_VIP_TOKENS`，默认仅第一个 token 用于 VIP 调用。
+
     * `TUSHARE_API_KEY`：旧变量名。若设置且 `TUSHARE_TOKEN` 留空，会自动映射为主凭证。
 
   * 程序会通过 python-dotenv 自动读取 `.env`，或从 shell 环境变量读取（变量名同上）。
+
+  * 若配置了多个 token，程序会在启动时打印积分检测结果，仅对满足门槛的 token 使用 VIP 接口。未检测到合格凭证且 `--use-vip` 为真时会直接报错退出，避免运行中途触发权限异常。
 
 * `.envrc`（本地，可选）：开发环境自动化脚本（需安装 direnv）。
 

--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -1,7 +1,8 @@
 import argparse
 import sys
 
-from .common import eprint, init_pro_api as _init_pro_api
+from .common import eprint
+from .common import init_pro_api as _init_pro_api
 
 # Re-export init_pro_api for tests that patch it at the CLI module level.
 init_pro_api = _init_pro_api

--- a/tests/integration/test_cli_overrides.py
+++ b/tests/integration/test_cli_overrides.py
@@ -3,12 +3,14 @@ import sys
 import pytest
 
 from tushare_a_fundamentals import cli as appmod
+from tushare_a_fundamentals.common import ProContext
 
 pytestmark = pytest.mark.integration
 
 
 def test_cli_requires_subcommand(monkeypatch):
-    monkeypatch.setattr(appmod, "init_pro_api", lambda token: object())
+    dummy_ctx = ProContext(any_client=object(), vip_client=object(), tokens=["tok"], vip_tokens=["tok"])
+    monkeypatch.setattr(appmod, "init_pro_api", lambda token: dummy_ctx)
     monkeypatch.setattr(sys, "argv", ["funda"])
     with pytest.raises(SystemExit) as excinfo:
         appmod.main()


### PR DESCRIPTION
## Summary
- introduce a ProContext wrapper that auto-detects VIP-capable TuShare tokens (with optional overrides) and share detection details in the CLI
- update the downloader to use separate client pools for VIP calls, honoring the detected tokens and warning when falling back
- document the new environment variables in README/.env.example and extend unit tests for CLI wiring and VIP client selection

## Testing
- pytest -m unit *(fails: pandas and project package are unavailable in the execution environment)*
- ruff check src tests *(fails: existing C901 complexity warnings in legacy helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68de8436df0c8327bc3828dd65e34055