### PR TITLE
fix: specify announcement date format

### DIFF
--- a/src/tushare_a_fundamentals/commands/export.py
+++ b/src/tushare_a_fundamentals/commands/export.py
@@ -248,8 +248,13 @@ def _export_single_dataset(opts: ExportOptions, name: str) -> int:
 
 def _write_dataset(source: Path, opts: ExportOptions, base_name: str) -> bool:
     try:
-        dataset = ds.dataset(source.as_posix(), format="parquet", partitioning="hive")
-    except (FileNotFoundError, ValueError, pa.ArrowInvalid):
+        partitioning = ds.partitioning(
+            pa.schema([pa.field("year", pa.string())]), flavor="hive"
+        )
+        dataset = ds.dataset(
+            source.as_posix(), format="parquet", partitioning=partitioning
+        )
+    except (FileNotFoundError, ValueError, pa.ArrowInvalid, pa.ArrowTypeError):
         return False
 
     scanner = ds.Scanner.from_dataset(dataset)

--- a/src/tushare_a_fundamentals/transforms/deduplicate.py
+++ b/src/tushare_a_fundamentals/transforms/deduplicate.py
@@ -16,7 +16,7 @@ def _prepare_sort_keys(df: pd.DataFrame) -> list[str]:
     # prefer f_ann_date over ann_date if both exist
     for col in ("f_ann_date", "ann_date"):
         if col in df.columns:
-            df[col] = pd.to_datetime(df[col], errors="coerce")
+            df[col] = pd.to_datetime(df[col], format="%Y%m%d", errors="coerce")
             sort_cols.append(col)
     return sort_cols
 


### PR DESCRIPTION
## Summary
- parse TuShare announcement dates with the explicit YYYYMMDD format to avoid pandas warnings during deduplication
- declare the Hive partition schema when exporting so year partitions are treated as strings and ArrowTypeError is handled gracefully

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df37e084d48327b460f75ad9e8ebee