### PR TITLE
Add coverage and docs for progress reporting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ recent_quarters: 4          # 刷新最近的季度数 (建议 2-4 覆盖常见�
 
 3. 查看/维护增量状态与失败清单：`funda state show|clear|ls-failures`
 
+### 进度展示
+
+下载和导出都可能需要较长时间，默认会根据终端能力自动选择进度输出：
+
+```bash
+# 默认 auto：TTY 下显示 Rich 进度条，重定向/CI 时退化为纯文本节奏提示
+funda download --progress auto
+
+# 固定使用 Rich 进度条或强制纯文本/关闭进度
+funda download --progress rich
+funda download --progress plain
+funda download --progress none
+
+# 导出命令同样支持 --progress
+funda export --progress plain
+```
+
+在进度条模式下，命令会展示任务总数、成功/失败计数和预计剩余时间；纯文本模式则每隔约 1.5 秒输出一次累计进度，兼容日志采集与重定向场景。
+
 ### 状态后端与 CLI 限制
 
 * 默认状态后端：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "numpy>=1.24.0",
     "python-dotenv>=1.0.0",
     "pyarrow>=14.0.0",
+    "rich>=13.7.0",
 ]
 
 [project.scripts]

--- a/src/tushare_a_fundamentals/cli.py
+++ b/src/tushare_a_fundamentals/cli.py
@@ -92,6 +92,12 @@ def parse_cli() -> argparse.Namespace:
         action="store_true",
         help="跳过平面导出，仅构建 income 派生表",
     )
+    sp_exp.add_argument(
+        "--progress",
+        choices=["auto", "rich", "plain", "none"],
+        default="auto",
+        help="进度展示模式：auto/rich/plain/none（默认 auto）",
+    )
 
     sp_cov = sub.add_parser("coverage", help="盘点已覆盖的股票×期末日")
     sp_cov.add_argument(
@@ -191,6 +197,12 @@ def parse_cli() -> argparse.Namespace:
         dest="max_per_minute",
         type=int,
         help="接口每分钟最大调用次数（默认 90）",
+    )
+    sp_dl.add_argument(
+        "--progress",
+        choices=["auto", "rich", "plain", "none"],
+        default="auto",
+        help="进度展示模式：auto/rich/plain/none（默认 auto）",
     )
     vip_toggle = sp_dl.add_mutually_exclusive_group()
     vip_toggle.add_argument(

--- a/src/tushare_a_fundamentals/commands/download.py
+++ b/src/tushare_a_fundamentals/commands/download.py
@@ -50,6 +50,7 @@ def _download_defaults() -> dict:
         "export_years": None,
         "export_strict": False,
         "max_retries": 3,
+        "progress": "auto",
     }
 
 
@@ -79,6 +80,7 @@ def _collect_cli_overrides(args: argparse.Namespace) -> dict:
         "export_years": getattr(args, "export_years", None),
         "export_strict": getattr(args, "export_strict", None),
         "max_retries": getattr(args, "max_retries", None),
+        "progress": getattr(args, "progress", None),
     }
     if getattr(args, "export_enabled", None) is not None:
         overrides["export_enabled"] = getattr(args, "export_enabled")
@@ -125,6 +127,7 @@ def _build_export_args(cfg: dict) -> Namespace | None:
         gzip=bool(cfg.get("export_gzip", False)),
         no_income=bool(cfg.get("export_no_income", False)),
         no_flat=bool(cfg.get("export_no_flat", False)),
+        progress=cfg.get("progress", "auto"),
     )
 
 
@@ -151,6 +154,10 @@ def cmd_download(args: argparse.Namespace) -> None:
     cfg = merge_config(cli_overrides, cfg_file, defaults)
     cfg["report_types"] = parse_report_types(cfg.get("report_types"))
     cfg["fields"] = normalize_fields(cfg.get("fields"))
+    raw_progress = str(cfg.get("progress", "auto") or "auto").strip().lower()
+    if raw_progress not in {"auto", "rich", "plain", "none"}:
+        raw_progress = "auto"
+    cfg["progress"] = raw_progress
     try:
         max_retries = int(cfg.get("max_retries", 3))
     except (TypeError, ValueError):
@@ -394,6 +401,7 @@ def _run_multi_dataset_flow(
         state_path=cfg.get("state_path"),
         allow_future=bool(cfg.get("allow_future")),
         max_retries=int(cfg.get("max_retries", 3)),
+        progress_mode=cfg.get("progress", "auto"),
     )
 
     downloader.run(

--- a/src/tushare_a_fundamentals/progress.py
+++ b/src/tushare_a_fundamentals/progress.py
@@ -1,0 +1,176 @@
+"""Lightweight progress reporting helpers for CLI workflows."""
+
+from __future__ import annotations
+
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Optional
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+
+def _is_tty(stream: Any) -> bool:
+    try:
+        return bool(stream.isatty())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+@dataclass
+class PlainTicker:
+    """Fallback progress reporter for plain text environments."""
+
+    desc: str
+    total: int
+    done: int = 0
+    every_sec: float = 1.5
+    last_print: float = 0.0
+    ok: Optional[int] = None
+    fail: Optional[int] = None
+
+    def advance(
+        self,
+        step: int = 1,
+        *,
+        ok: Optional[int] = None,
+        fail: Optional[int] = None,
+    ) -> None:
+        self.done += step
+        if self.total >= 0:
+            self.done = min(self.done, self.total)
+        if ok is not None:
+            self.ok = ok
+        if fail is not None:
+            self.fail = fail
+        now = time.time()
+        if (
+            now - self.last_print >= self.every_sec
+            or (self.total > 0 and self.done >= self.total)
+        ):
+            parts = [f"[..] {self.desc}: {self.done}/{self.total if self.total else '?'}"]
+            stats: list[str] = []
+            if self.ok is not None:
+                stats.append(f"✓{self.ok}")
+            if self.fail is not None and self.fail > 0:
+                stats.append(f"✗{self.fail}")
+            if stats:
+                parts.append("(" + " ".join(stats) + ")")
+            print(" ".join(parts), flush=True)
+            self.last_print = now
+
+
+class ProgressManager:
+    """Encapsulates progress bar or plain ticker behaviour."""
+
+    def __init__(self, mode: str = "auto") -> None:
+        normalized = (mode or "auto").strip().lower()
+        if normalized not in {"auto", "rich", "plain", "none"}:
+            normalized = "auto"
+        self.mode = normalized
+        self._base_descriptions: Dict[Any, str] = {}
+
+        self._use_rich = False
+        self._use_plain = False
+
+        if normalized == "none":
+            pass
+        elif normalized == "rich":
+            self._use_rich = True
+        elif normalized == "plain":
+            self._use_plain = True
+        else:  # auto
+            if _is_tty(sys.stderr):
+                self._use_rich = True
+            else:
+                self._use_plain = True
+
+        self.console: Optional[Console] = None
+        self.progress: Optional[Progress] = None
+        if self._use_rich:
+            self.console = Console(
+                stderr=True,
+                force_terminal=False,
+                highlight=False,
+                soft_wrap=True,
+            )
+            self.progress = Progress(
+                SpinnerColumn(),
+                TextColumn("{task.description}"),
+                BarColumn(),
+                TaskProgressColumn(),
+                TimeElapsedColumn(),
+                TimeRemainingColumn(),
+                transient=True,
+                refresh_per_second=5,
+                console=self.console,
+            )
+
+    @property
+    def is_active(self) -> bool:
+        return self._use_rich or self._use_plain
+
+    @contextmanager
+    def live(self) -> Iterator["ProgressManager"]:
+        if self.progress is not None:
+            with self.progress:
+                yield self
+        else:
+            yield self
+
+    def add_task(self, description: str, total: int) -> Any:
+        if not self.is_active or total <= 0:
+            return None
+        if self.progress is not None:
+            task_id: TaskID = self.progress.add_task(description, total=total)
+            self._base_descriptions[task_id] = description
+            return task_id
+        ticker = PlainTicker(description, total)
+        self._base_descriptions[id(ticker)] = description
+        return ticker
+
+    def advance(
+        self,
+        task: Any,
+        step: int = 1,
+        *,
+        ok: Optional[int] = None,
+        fail: Optional[int] = None,
+    ) -> None:
+        if task is None:
+            return
+        if self.progress is not None and isinstance(task, int):
+            base = self._base_descriptions.get(task)
+            description = base
+            stats: list[str] = []
+            if ok is not None:
+                stats.append(f"✓{ok}")
+            if fail is not None and fail > 0:
+                stats.append(f"✗{fail}")
+            if stats and base:
+                description = f"{base}  [{' '.join(stats)}]"
+            update_kwargs: Dict[str, Any] = {"advance": step}
+            if description is not None:
+                update_kwargs["description"] = description
+            self.progress.update(task, **update_kwargs)
+            return
+        if isinstance(task, PlainTicker):
+            task.advance(step, ok=ok, fail=fail)
+
+    def log(self, message: str) -> None:
+        if self.console is not None:
+            self.console.print(message)
+        else:
+            print(message)
+

--- a/tests/unit/test_download_cmd.py
+++ b/tests/unit/test_download_cmd.py
@@ -59,6 +59,7 @@ def test_cmd_download_multi_dataset_uses_configured_years(monkeypatch, tmp_path)
         export_enabled=None,
         no_export=True,
         max_retries=None,
+        progress="plain",
     )
 
     download_cmd.cmd_download(args)
@@ -70,3 +71,58 @@ def test_cmd_download_multi_dataset_uses_configured_years(monkeypatch, tmp_path)
     assert len(captured["end"]) == 8
     assert captured["start"] <= captured["end"]
     assert captured["refresh"] == 4
+    assert captured["init_kwargs"]["progress_mode"] == "plain"
+
+
+def test_cmd_download_invalid_progress_falls_back(monkeypatch, tmp_path):
+    captured = {}
+
+    class DummyDownloader:
+        def __init__(self, pro, data_dir, *, vip_pro=None, **kwargs):
+            captured["progress_mode"] = kwargs.get("progress_mode")
+
+        def run(self, requests, *, start=None, end=None, refresh_periods=0):
+            pass
+
+    monkeypatch.setattr(download_cmd, "MarketDatasetDownloader", DummyDownloader)
+    dummy_ctx = ProContext(
+        any_client=object(), vip_client=object(), tokens=["tok"], vip_tokens=["tok"]
+    )
+    monkeypatch.setattr(download_cmd, "init_pro_api", lambda token: dummy_ctx)
+    monkeypatch.setattr(download_cmd, "ensure_enough_credits", lambda pro, required=5000: None)
+    monkeypatch.setattr(download_cmd, "load_yaml", lambda path: {})
+
+    args = Namespace(
+        config=None,
+        datasets=["income"],
+        years=None,
+        quarters=None,
+        since=None,
+        until=None,
+        fields="",
+        outdir=None,
+        prefix=None,
+        format=None,
+        token=None,
+        report_types=None,
+        allow_future=False,
+        recent_quarters=None,
+        data_dir=str(tmp_path),
+        use_vip=None,
+        max_per_minute=None,
+        state_path=None,
+        export_out_dir=None,
+        export_out_format=None,
+        export_kinds=None,
+        export_annual_strategy=None,
+        export_years=None,
+        export_strict=None,
+        export_enabled=None,
+        no_export=True,
+        max_retries=None,
+        progress="???",
+    )
+
+    download_cmd.cmd_download(args)
+
+    assert captured["progress_mode"] == "auto"

--- a/tests/unit/test_download_multi_export.py
+++ b/tests/unit/test_download_multi_export.py
@@ -81,3 +81,4 @@ def test_cmd_download_runs_export_when_enabled(monkeypatch, tmp_path):
     assert ns.gzip is False
     assert ns.no_income is False
     assert ns.no_flat is False
+    assert ns.progress == "auto"

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("rich")
+
+import tushare_a_fundamentals.progress as progress
+from tushare_a_fundamentals.progress import PlainTicker, ProgressManager
+
+pytestmark = pytest.mark.unit
+
+
+def test_progress_manager_none_mode():
+    pm = ProgressManager("none")
+    assert pm.is_active is False
+    task = pm.add_task("任务", 5)
+    assert task is None
+    with pm.live() as live_pm:
+        assert live_pm is pm
+    # advance should be a no-op
+    pm.advance(task, ok=1, fail=0)
+
+
+def test_progress_manager_plain_outputs(monkeypatch, capsys):
+    pm = ProgressManager("plain")
+    task = pm.add_task("下载", 3)
+    assert isinstance(task, PlainTicker)
+
+    monkeypatch.setattr(progress.time, "time", lambda: 2.0)
+
+    pm.advance(task, ok=1)
+    captured = capsys.readouterr().out
+    assert "下载" in captured
+    assert "1/3" in captured
+    assert "✓1" in captured
+
+
+def test_progress_manager_auto_prefers_rich_when_tty(monkeypatch):
+    monkeypatch.setattr(progress, "_is_tty", lambda stream: True)
+    pm = ProgressManager("auto")
+    assert pm.progress is not None
+    assert pm.console is not None

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -525,6 +546,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +720,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "tushare" },
 ]
 
@@ -703,6 +738,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.7.0" },
     { name = "tushare", specifier = ">=1.2.89" },
 ]
 


### PR DESCRIPTION
## Summary
- document the --progress flag usage modes in the README so users can discover the new UI options
- add unit coverage for the ProgressManager fallback behaviour and ensure CLI wiring passes the requested progress mode through to downloads and exports

## Testing
- PYTHONPATH=src pytest tests/unit/test_progress.py
- PYTHONPATH=src pytest tests/unit/test_download_cmd.py tests/unit/test_download_multi_export.py

------
https://chatgpt.com/codex/tasks/task_e_68dfba0166e883278116fc25e67b4758