### PR TITLE
feat: add audit-only window overrides

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,8 +5,13 @@
 # from the latest available quarter. For example, years: 10 equals 40 quarters.
 # Alternatively, comment out 'years' and set 'quarters' directly.
 # Priority: --since/--until > quarters > years.
+#
+# 审计数据（`--audit-only`）可以通过 `audit_quarters`/`audit_years`
+# 独立配置回溯窗口；若未指定，则在未提供任何全局时间窗口时默认回溯 1 个季度。
 years: 10
 # quarters: 40
+audit_quarters: 1
+# audit_years: 1
 
 
 # --- Data refresh ---

--- a/tests/unit/test_download_cmd.py
+++ b/tests/unit/test_download_cmd.py
@@ -126,3 +126,151 @@ def test_cmd_download_invalid_progress_falls_back(monkeypatch, tmp_path):
     download_cmd.cmd_download(args)
 
     assert captured["progress_mode"] == "auto"
+
+
+def test_cmd_download_audit_only_prefers_audit_quarters(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class DummyDownloader:
+        def __init__(self, pro, data_dir, *, vip_pro=None, **kwargs):
+            captured["data_dir"] = data_dir
+
+        def run(self, requests, *, start=None, end=None, refresh_periods=0):
+            captured["requests"] = requests
+            captured["start"] = start
+            captured["end"] = end
+            captured["refresh"] = refresh_periods
+
+    def fake_periods_from_cfg(cfg):
+        captured["quarters_cfg"] = cfg.get("quarters")
+        captured["years_cfg"] = cfg.get("years")
+        return ["20240101", "20240331"]
+
+    monkeypatch.setattr(download_cmd, "MarketDatasetDownloader", DummyDownloader)
+    monkeypatch.setattr(download_cmd, "_periods_from_cfg", fake_periods_from_cfg)
+    dummy_ctx = ProContext(
+        any_client=object(), vip_client=object(), tokens=["tok"], vip_tokens=["tok"]
+    )
+    monkeypatch.setattr(download_cmd, "init_pro_api", lambda token: dummy_ctx)
+    monkeypatch.setattr(download_cmd, "ensure_enough_credits", lambda pro, required=5000: None)
+    monkeypatch.setattr(
+        download_cmd,
+        "load_yaml",
+        lambda path: {"years": 10, "audit_quarters": 1},
+    )
+
+    args = Namespace(
+        config=None,
+        datasets=None,
+        years=None,
+        quarters=None,
+        since=None,
+        until=None,
+        audit_quarters=None,
+        audit_years=None,
+        audit_only=True,
+        with_audit=False,
+        all=False,
+        fields="",
+        outdir=None,
+        prefix=None,
+        format=None,
+        token=None,
+        report_types=None,
+        allow_future=False,
+        recent_quarters=None,
+        data_dir=str(tmp_path),
+        use_vip=None,
+        max_per_minute=None,
+        state_path=None,
+        export_out_dir=None,
+        export_out_format=None,
+        export_kinds=None,
+        export_annual_strategy=None,
+        export_years=None,
+        export_strict=None,
+        export_enabled=None,
+        no_export=True,
+        max_retries=None,
+        progress="plain",
+    )
+
+    download_cmd.cmd_download(args)
+
+    assert captured["quarters_cfg"] == 1
+    assert captured["years_cfg"] is None
+    assert captured["requests"] and captured["requests"][0].name == "fina_audit"
+    assert captured["start"] == "20240101"
+    assert captured["end"] == "20240331"
+
+
+def test_cmd_download_audit_only_falls_back_to_one_quarter(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class DummyDownloader:
+        def __init__(self, pro, data_dir, *, vip_pro=None, **kwargs):
+            captured["data_dir"] = data_dir
+
+        def run(self, requests, *, start=None, end=None, refresh_periods=0):
+            captured["requests"] = requests
+            captured["start"] = start
+            captured["end"] = end
+            captured["refresh"] = refresh_periods
+
+    def fake_periods_from_cfg(cfg):
+        captured["quarters_cfg"] = cfg.get("quarters")
+        captured["years_cfg"] = cfg.get("years")
+        return ["20240101", "20240331"]
+
+    monkeypatch.setattr(download_cmd, "MarketDatasetDownloader", DummyDownloader)
+    monkeypatch.setattr(download_cmd, "_periods_from_cfg", fake_periods_from_cfg)
+    dummy_ctx = ProContext(
+        any_client=object(), vip_client=object(), tokens=["tok"], vip_tokens=["tok"]
+    )
+    monkeypatch.setattr(download_cmd, "init_pro_api", lambda token: dummy_ctx)
+    monkeypatch.setattr(download_cmd, "ensure_enough_credits", lambda pro, required=5000: None)
+    monkeypatch.setattr(download_cmd, "load_yaml", lambda path: None)
+
+    args = Namespace(
+        config=None,
+        datasets=None,
+        years=None,
+        quarters=None,
+        since=None,
+        until=None,
+        audit_quarters=None,
+        audit_years=None,
+        audit_only=True,
+        with_audit=False,
+        all=False,
+        fields="",
+        outdir=None,
+        prefix=None,
+        format=None,
+        token=None,
+        report_types=None,
+        allow_future=False,
+        recent_quarters=None,
+        data_dir=str(tmp_path),
+        use_vip=None,
+        max_per_minute=None,
+        state_path=None,
+        export_out_dir=None,
+        export_out_format=None,
+        export_kinds=None,
+        export_annual_strategy=None,
+        export_years=None,
+        export_strict=None,
+        export_enabled=None,
+        no_export=True,
+        max_retries=None,
+        progress="plain",
+    )
+
+    download_cmd.cmd_download(args)
+
+    assert captured["quarters_cfg"] == 1
+    assert captured["years_cfg"] is None
+    assert captured["requests"] and captured["requests"][0].name == "fina_audit"
+    assert captured["start"] == "20240101"
+    assert captured["end"] == "20240331"


### PR DESCRIPTION
## Summary
- add audit_quarters/audit_years defaults and merge logic so audit-only downloads honor dedicated windows
- document the new audit window keys in `config.example.yaml`
- cover audit-only overrides and fallback behavior with new unit tests

## Testing
- PYTHONPATH=src pytest tests/unit/test_download_cmd.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f53b763c8327820c3f527693cbd0