### PR TITLE
Skip VIP credit gate for audit-only downloads

### DIFF
--- a/src/tushare_a_fundamentals/workflows/download.py
+++ b/src/tushare_a_fundamentals/workflows/download.py
@@ -98,7 +98,13 @@ def run_download_pipeline(
     exporter = export_callback or run_export
 
     ctx = init_fn(cfg.get("token"))
-    if use_vip:
+
+    dataset_requests = tuple(dataset_requests)
+    is_audit_only = bool(dataset_requests) and all(
+        getattr(req, "name", None) == "fina_audit" for req in dataset_requests
+    )
+
+    if use_vip and not is_audit_only:
         if not ctx.vip_tokens:
             raise DownloadExecutionError(
                 "未检测到满足 VIP 门槛（≥5000 积分）的 token。"


### PR DESCRIPTION
## Summary
- skip the VIP credit requirement when the download pipeline is invoked exclusively for `fina_audit`
- reuse the requested dataset sequence to detect audit-only runs without changing other flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21d99871883278d3bdbd686e3e9e5